### PR TITLE
change TTLs to time.Duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ key. It will return 0 when no TTL is set. EXPIREAT and PEXPIREAT values will be
 converted to a duration. For that you can either set m.SetTime(t) to use that
 time as the base for the (P)EXPIREAT conversion, or don't call SetTime(), in
 which case time.Now() will be used.
+`m.FastForward(d)` can be used to decrement all TTLs. All TTLs which become <=
+0 will be removed.
 
 ## Example
 
@@ -182,6 +184,14 @@ func TestSomething(t *testing.T) {
     }
     // ... or use a helper for that:
     s.CheckGet(t, "foo", "bar")
+
+    // TTL and expiration:
+    s.Set("foo", "bar")
+    s.SetTTL("foo", 10 * time.Second)
+    s.FastForward(11 * time.Second)
+    if s.Exists("foo") {
+        t.Fatal("'foo' should not have existed anymore")
+    }
 }
 ```
 
@@ -243,7 +253,7 @@ Commands which will probably not be implemented:
 ## &c.
 
 See https://github.com/alicebob/miniredis_vs_redis for tests comparing
-miniredis against the real thing. Tests are run against Redis 3.2.1 (Debian).
+miniredis against the real thing. Tests are run against Redis 3.2.5 (Debian).
 
 
 [![Build Status](https://travis-ci.org/alicebob/miniredis.svg?branch=master)](https://travis-ci.org/alicebob/miniredis) 

--- a/README.md
+++ b/README.md
@@ -150,10 +150,12 @@ Implemented commands:
    - ZSCAN
 
 
-Since miniredis is intended to be used in unittests timeouts are not implemented.
-You can use `Expire()` to see if an expiration is set. The value returned will
-be that what the client set, without any interpretation. This is to keep things
-testable.
+Since miniredis is intended to be used in unittests TTLs don't decrease
+automatically. You can use `TTL()` to get the TTL (as a time.Duration) of a
+key. It will return 0 when no TTL is set. EXPIREAT and PEXPIREAT values will be
+converted to a duration. For that you can either set m.SetTime(t) to use that
+time as the base for the (P)EXPIREAT conversion, or don't call SetTime(), in
+which case time.Now() will be used.
 
 ## Example
 

--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -85,6 +85,7 @@ func makeCmdExpire(m *Miniredis, unix bool, d time.Duration) func(*redeo.Respond
 				db.ttl[key] = time.Duration(i) * d
 			}
 			db.keyVersion[key]++
+			db.checkTTL(key)
 			out.WriteOne()
 		})
 	}

--- a/cmd_generic_test.go
+++ b/cmd_generic_test.go
@@ -96,6 +96,14 @@ func TestTTL(t *testing.T) {
 		ok(t, err)
 		equals(t, 1, b)
 	}
+
+	{
+		_, err = c.Do("SET", "wim", "zus")
+		ok(t, err)
+		_, err = redis.Int(c.Do("EXPIRE", "wim", -1200))
+		ok(t, err)
+		equals(t, false, s.Exists("wim"))
+	}
 }
 
 func TestExpireat(t *testing.T) {

--- a/cmd_hash_test.go
+++ b/cmd_hash_test.go
@@ -3,6 +3,7 @@ package miniredis
 import (
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/garyburd/redigo/redis"
 )
@@ -118,11 +119,11 @@ func TestHashMSet(t *testing.T) {
 
 	// Doesn't touch ttl.
 	{
-		s.SetExpire("hash", 999)
+		s.SetTTL("hash", time.Second*999)
 		v, err := redis.String(c.Do("HMSET", "hash", "gijs", "lam"))
 		ok(t, err)
 		equals(t, "OK", v)
-		equals(t, 999, s.Expire("hash"))
+		equals(t, time.Second*999, s.TTL("hash"))
 	}
 
 	{

--- a/cmd_string.go
+++ b/cmd_string.go
@@ -83,6 +83,11 @@ func (m *Miniredis) cmdSet(out *redeo.Responder, r *redeo.Request) error {
 				return nil
 			}
 			ttl = time.Duration(expire) * timeUnit
+			if ttl <= 0 {
+				setDirty(r.Client())
+				out.WriteErrorString(msgInvalidSETime)
+				return nil
+			}
 
 			r.Args = r.Args[2:]
 			continue
@@ -135,6 +140,11 @@ func (m *Miniredis) cmdSetex(out *redeo.Responder, r *redeo.Request) error {
 		out.WriteErrorString(msgInvalidInt)
 		return nil
 	}
+	if ttl <= 0 {
+		setDirty(r.Client())
+		out.WriteErrorString(msgInvalidSETEXTime)
+		return nil
+	}
 	value := r.Args[2]
 
 	return withTx(m, out, r, func(out *redeo.Responder, ctx *connCtx) {
@@ -161,6 +171,11 @@ func (m *Miniredis) cmdPsetex(out *redeo.Responder, r *redeo.Request) error {
 	if err != nil {
 		setDirty(r.Client())
 		out.WriteErrorString(msgInvalidInt)
+		return nil
+	}
+	if ttl <= 0 {
+		setDirty(r.Client())
+		out.WriteErrorString(msgInvalidPSETEXTime)
 		return nil
 	}
 	value := r.Args[2]

--- a/cmd_string_test.go
+++ b/cmd_string_test.go
@@ -144,6 +144,11 @@ func TestSet(t *testing.T) {
 
 		_, err = c.Do("SET", "one", "two", "EX")
 		assert(t, err != nil, "no SET error on missing EX argument")
+
+		_, err = redis.String(c.Do("SET", "aap", "noot", "EX", 0))
+		assert(t, err != nil, "no SET EX error")
+		_, err = redis.String(c.Do("SET", "aap", "noot", "EX", -100))
+		assert(t, err != nil, "no SET EX error")
 	}
 
 	// Invalid argument
@@ -260,6 +265,10 @@ func TestSetex(t *testing.T) {
 		assert(t, err != nil, "no SETEX error")
 		_, err = redis.String(c.Do("SETEX", "aap", 12, "noot", "toomuch"))
 		assert(t, err != nil, "no SETEX error")
+		_, err = redis.String(c.Do("SETEX", "aap", 0, "noot"))
+		assert(t, err != nil, "no SETEX error")
+		_, err = redis.String(c.Do("SETEX", "aap", -10, "noot"))
+		assert(t, err != nil, "no SETEX error")
 	}
 }
 
@@ -294,6 +303,10 @@ func TestPsetex(t *testing.T) {
 		_, err = redis.String(c.Do("PSETEX", "aap", 12))
 		assert(t, err != nil, "no PSETEX error")
 		_, err = redis.String(c.Do("PSETEX", "aap", 12, "noot", "toomuch"))
+		assert(t, err != nil, "no PSETEX error")
+		_, err = redis.String(c.Do("PSETEX", "aap", 0, "noot"))
+		assert(t, err != nil, "no PSETEX error")
+		_, err = redis.String(c.Do("PSETEX", "aap", -10, "noot"))
 		assert(t, err != nil, "no PSETEX error")
 	}
 }

--- a/db.go
+++ b/db.go
@@ -534,7 +534,7 @@ func (db *RedisDB) setUnion(keys []string) (setKey, error) {
 }
 
 // fastForward proceeds the current timestamp with duration, works as a time machine
-func (db *RedisDB) fastForward(duration time.Duration) () {
+func (db *RedisDB) fastForward(duration time.Duration) {
 	for _, key := range db.allKeys() {
 		value, ok := db.ttl[key]
 		if ok {

--- a/db.go
+++ b/db.go
@@ -536,8 +536,7 @@ func (db *RedisDB) setUnion(keys []string) (setKey, error) {
 // fastForward proceeds the current timestamp with duration, works as a time machine
 func (db *RedisDB) fastForward(duration time.Duration) {
 	for _, key := range db.allKeys() {
-		value, ok := db.ttl[key]
-		if ok {
+		if value, ok := db.ttl[key]; ok {
 			db.ttl[key] = value - duration
 			if db.ttl[key] <= 0 {
 				db.del(key, true)

--- a/db.go
+++ b/db.go
@@ -538,9 +538,13 @@ func (db *RedisDB) fastForward(duration time.Duration) {
 	for _, key := range db.allKeys() {
 		if value, ok := db.ttl[key]; ok {
 			db.ttl[key] = value - duration
-			if db.ttl[key] <= 0 {
-				db.del(key, true)
-			}
+			db.checkTTL(key)
 		}
+	}
+}
+
+func (db *RedisDB) checkTTL(key string) {
+	if v, ok := db.ttl[key]; ok && v <= 0 {
+		db.del(key, true)
 	}
 }

--- a/db.go
+++ b/db.go
@@ -532,3 +532,16 @@ func (db *RedisDB) setUnion(keys []string) (setKey, error) {
 	}
 	return s, nil
 }
+
+// fastForward proceeds the current timestamp with duration, works as a time machine
+func (db *RedisDB) fastForward(duration time.Duration) () {
+	for _, key := range db.allKeys() {
+		value, ok := db.expire[key]
+		if ok {
+			db.expire[key] = value - int(duration)
+			if db.expire[key] <= 0 {
+				db.del(key, true)
+			}
+		}
+	}
+}

--- a/db.go
+++ b/db.go
@@ -536,10 +536,10 @@ func (db *RedisDB) setUnion(keys []string) (setKey, error) {
 // fastForward proceeds the current timestamp with duration, works as a time machine
 func (db *RedisDB) fastForward(duration time.Duration) () {
 	for _, key := range db.allKeys() {
-		value, ok := db.expire[key]
+		value, ok := db.ttl[key]
 		if ok {
-			db.expire[key] = value - int(duration)
-			if db.expire[key] <= 0 {
+			db.ttl[key] = value - duration
+			if db.ttl[key] <= 0 {
 				db.del(key, true)
 			}
 		}

--- a/direct.go
+++ b/direct.go
@@ -4,6 +4,7 @@ package miniredis
 
 import (
 	"errors"
+	"time"
 )
 
 var (
@@ -311,30 +312,32 @@ func (db *RedisDB) Del(k string) bool {
 	return true
 }
 
-// Expire value. As set by the client (via EXPIRE, PEXPIRE, EXPIREAT, PEXPIREAT and
-// similar commands). 0 if not set.
-func (m *Miniredis) Expire(k string) int {
-	return m.DB(m.selectedDB).Expire(k)
+// TTL is the left over time to live. As set via EXPIRE, PEXPIRE, EXPIREAT,
+// PEXPIREAT.
+// 0 if not set.
+func (m *Miniredis) TTL(k string) time.Duration {
+	return m.DB(m.selectedDB).TTL(k)
 }
 
-// Expire value. As set by the client (via EXPIRE, PEXPIRE, EXPIREAT, PEXPIREAT and
-// similar commands). 0 if not set.
-func (db *RedisDB) Expire(k string) int {
+// TTL is the left over time to live. As set via EXPIRE, PEXPIRE, EXPIREAT,
+// PEXPIREAT.
+// 0 if not set.
+func (db *RedisDB) TTL(k string) time.Duration {
 	db.master.Lock()
 	defer db.master.Unlock()
-	return db.expire[k]
+	return db.ttl[k]
 }
 
-// SetExpire sets expiration of a key.
-func (m *Miniredis) SetExpire(k string, ex int) {
-	m.DB(m.selectedDB).SetExpire(k, ex)
+// SetTTL sets the TTL of a key.
+func (m *Miniredis) SetTTL(k string, ttl time.Duration) {
+	m.DB(m.selectedDB).SetTTL(k, ttl)
 }
 
-// SetExpire sets expiration of a key.
-func (db *RedisDB) SetExpire(k string, ex int) {
+// SetTTL sets the time to live of a key.
+func (db *RedisDB) SetTTL(k string, ttl time.Duration) {
 	db.master.Lock()
 	defer db.master.Unlock()
-	db.expire[k] = ex
+	db.ttl[k] = ttl
 	db.keyVersion[k]++
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -32,6 +32,14 @@ func Example() {
 	if _, err := s.DB(42).Get("foo"); err != miniredis.ErrKeyNotFound {
 		panic("Didn't use a different DB")
 	}
+
+	// Test key with expiration
+	s.SetTTL("foo", 60)
+	s.FastForward(60)
+	if _, err := s.Get("foo"); err == nil {
+		panic("Expect key expired, but still get value.")
+	}
+
 	// Or use a Check* function which Fail()s if the key is not what we expect
 	// (checks for existence, key type and the value)
 	// s.CheckGet(t, "foo", "bar")

--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,8 @@
 package miniredis_test
 
 import (
+	"time"
+
 	"github.com/alicebob/miniredis"
 	"github.com/garyburd/redigo/redis"
 )
@@ -34,10 +36,10 @@ func Example() {
 	}
 
 	// Test key with expiration
-	s.SetTTL("foo", 60)
-	s.FastForward(60)
-	if _, err := s.Get("foo"); err == nil {
-		panic("Expect key expired, but still get value.")
+	s.SetTTL("foo", 60*time.Second)
+	s.FastForward(60 * time.Second)
+	if s.Exists("foo") {
+		panic("Expect key to be expired")
 	}
 
 	// Or use a Check* function which Fail()s if the key is not what we expect

--- a/miniredis.go
+++ b/miniredis.go
@@ -300,6 +300,8 @@ func (m *Miniredis) Dump() string {
 // SetTime sets the time against which EXPIREAT values are compared. EXPIREAT
 // will use time.Now() if this is not set.
 func (m *Miniredis) SetTime(t time.Time) {
+	m.Lock()
+	defer m.Unlock()
 	m.now = t
 }
 

--- a/miniredis.go
+++ b/miniredis.go
@@ -249,6 +249,12 @@ func (m *Miniredis) TotalConnectionCount() int {
 	return int(m.srv.Info().TotalConnections())
 }
 
+// FastForward proceeds the time of selected db by duration.
+func (m *Miniredis) FastForward(duration time.Duration) () {
+	db := m.db(m.selectedDB)
+	db.fastForward(duration)
+}
+
 // Dump returns a text version of the selected DB, usable for debugging.
 func (m *Miniredis) Dump() string {
 	m.Lock()

--- a/miniredis.go
+++ b/miniredis.go
@@ -250,7 +250,7 @@ func (m *Miniredis) TotalConnectionCount() int {
 }
 
 // FastForward proceeds the time of selected db by duration.
-func (m *Miniredis) FastForward(duration time.Duration) () {
+func (m *Miniredis) FastForward(duration time.Duration) {
 	for _, db := range m.dbs {
 		db.fastForward(duration)
 	}

--- a/miniredis.go
+++ b/miniredis.go
@@ -251,8 +251,9 @@ func (m *Miniredis) TotalConnectionCount() int {
 
 // FastForward proceeds the time of selected db by duration.
 func (m *Miniredis) FastForward(duration time.Duration) () {
-	db := m.db(m.selectedDB)
-	db.fastForward(duration)
+	for _, db := range m.dbs {
+		db.fastForward(duration)
+	}
 }
 
 // Dump returns a text version of the selected DB, usable for debugging.

--- a/miniredis.go
+++ b/miniredis.go
@@ -249,8 +249,11 @@ func (m *Miniredis) TotalConnectionCount() int {
 	return int(m.srv.Info().TotalConnections())
 }
 
-// FastForward proceeds the time of selected db by duration.
+// FastForward decreases all TTLs by the given duration. All TTLs <= 0 will be
+// expired.
 func (m *Miniredis) FastForward(duration time.Duration) {
+	m.Lock()
+	defer m.Unlock()
 	for _, db := range m.dbs {
 		db.fastForward(duration)
 	}

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -188,7 +188,7 @@ func TestExpireWithFastForward(t *testing.T) {
 	ok(t, err)
 	s.Set("aap", "noot")
 	equals(t, []string{"aap"}, s.Keys())
-	s.SetExpire("aap", 10)
+	s.SetTTL("aap", 10)
 
 	s.FastForward(10)
 	equals(t, []string{}, s.Keys())

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -182,3 +182,14 @@ func TestKeysAndFlush(t *testing.T) {
 	s.Select(1)
 	equals(t, []string{}, s.Keys())
 }
+
+func TestExpireWithFastForward(t *testing.T) {
+	s, err := Run()
+	ok(t, err)
+	s.Set("aap", "noot")
+	equals(t, []string{"aap"}, s.Keys())
+	s.SetExpire("aap", 10)
+
+	s.FastForward(10)
+	equals(t, []string{}, s.Keys())
+}

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -187,6 +187,7 @@ func TestKeysAndFlush(t *testing.T) {
 func TestExpireWithFastForward(t *testing.T) {
 	s, err := Run()
 	ok(t, err)
+
 	s.Set("aap", "noot")
 	s.Set("noot", "aap")
 	s.SetTTL("aap", 10*time.Second)

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -2,6 +2,7 @@ package miniredis
 
 import (
 	"testing"
+	"time"
 
 	"github.com/garyburd/redigo/redis"
 )
@@ -187,9 +188,12 @@ func TestExpireWithFastForward(t *testing.T) {
 	s, err := Run()
 	ok(t, err)
 	s.Set("aap", "noot")
-	equals(t, []string{"aap"}, s.Keys())
-	s.SetTTL("aap", 10)
+	s.Set("noot", "aap")
+	s.SetTTL("aap", 10*time.Second)
 
-	s.FastForward(10)
-	equals(t, []string{}, s.Keys())
+	s.FastForward(5 * time.Second)
+	equals(t, 2, len(s.Keys()))
+
+	s.FastForward(5 * time.Second)
+	equals(t, 1, len(s.Keys()))
 }

--- a/redis.go
+++ b/redis.go
@@ -11,18 +11,21 @@ import (
 )
 
 const (
-	msgWrongType        = "WRONGTYPE Operation against a key holding the wrong kind of value"
-	msgInvalidInt       = "ERR value is not an integer or out of range"
-	msgInvalidFloat     = "ERR value is not a valid float"
-	msgInvalidMinMax    = "ERR min or max is not a float"
-	msgInvalidRangeItem = "ERR min or max not valid string range item"
-	msgInvalidTimeout   = "ERR timeout is not an integer or out of range"
-	msgSyntaxError      = "ERR syntax error"
-	msgKeyNotFound      = "ERR no such key"
-	msgOutOfRange       = "ERR index out of range"
-	msgInvalidCursor    = "ERR invalid cursor"
-	msgXXandNX          = "ERR XX and NX options at the same time are not compatible"
-	msgNegTimeout       = "ERR timeout is negative"
+	msgWrongType         = "WRONGTYPE Operation against a key holding the wrong kind of value"
+	msgInvalidInt        = "ERR value is not an integer or out of range"
+	msgInvalidFloat      = "ERR value is not a valid float"
+	msgInvalidMinMax     = "ERR min or max is not a float"
+	msgInvalidRangeItem  = "ERR min or max not valid string range item"
+	msgInvalidTimeout    = "ERR timeout is not an integer or out of range"
+	msgSyntaxError       = "ERR syntax error"
+	msgKeyNotFound       = "ERR no such key"
+	msgOutOfRange        = "ERR index out of range"
+	msgInvalidCursor     = "ERR invalid cursor"
+	msgXXandNX           = "ERR XX and NX options at the same time are not compatible"
+	msgNegTimeout        = "ERR timeout is negative"
+	msgInvalidSETime     = "ERR invalid expire time in set"
+	msgInvalidSETEXTime  = "ERR invalid expire time in setex"
+	msgInvalidPSETEXTime = "ERR invalid expire time in psetex"
 )
 
 // withTx wraps the non-argument-checking part of command handling code in


### PR DESCRIPTION
This removes m.Expire(), so if this is merged we'll update to 2.0.0.

This is to make #13 and #14 nicer.