### PR TITLE
move to function based tests

### DIFF
--- a/cmd_string_test.go
+++ b/cmd_string_test.go
@@ -771,30 +771,23 @@ func TestGetrange(t *testing.T) {
 
 	{
 		s.Set("foo", "abcdefg")
-		type tc struct {
-			s   int
-			e   int
-			res string
+		test := func(s, e int, res string) {
+			t.Helper()
+			v, err := redis.String(c.Do("GETRANGE", "foo", s, e))
+			ok(t, err)
+			equals(t, res, v)
 		}
-		for _, p := range []tc{
-			{0, 0, "a"},
-			{0, 3, "abcd"},
-			{0, 7, "abcdefg"},
-			{0, 100, "abcdefg"},
-			{1, 2, "bc"},
-			{1, 100, "bcdefg"},
-			{-4, -2, "def"},
-			{0, -1, "abcdefg"},
-			{0, -2, "abcdef"},
-			{0, -100, "a"}, // Redis is funny
-			{-2, 2, ""},
-		} {
-			{
-				v, err := redis.String(c.Do("GETRANGE", "foo", p.s, p.e))
-				ok(t, err)
-				equals(t, p.res, v)
-			}
-		}
+		test(0, 0, "a")
+		test(0, 3, "abcd")
+		test(0, 7, "abcdefg")
+		test(0, 100, "abcdefg")
+		test(1, 2, "bc")
+		test(1, 100, "bcdefg")
+		test(-4, -2, "def")
+		test(0, -1, "abcdefg")
+		test(0, -2, "abcdef")
+		test(0, -100, "a") // Redis is funny
+		test(-2, 2, "")
 	}
 
 	// New key
@@ -904,22 +897,15 @@ func TestBitcount(t *testing.T) {
 		// c: 0x1100011 - 4
 		// d: 0x1100100 - 3
 		s.Set("foo", "abcd")
-		type tc struct {
-			s   int
-			e   int
-			res int
+		test := func(s, e, res int) {
+			t.Helper()
+			v, err := redis.Int(c.Do("BITCOUNT", "foo", s, e))
+			ok(t, err)
+			equals(t, res, v)
 		}
-		for _, p := range []tc{
-			{0, 0, 3},   // "a"
-			{0, 3, 13},  // "abcd"
-			{-2, -2, 4}, // "c"
-		} {
-			{
-				v, err := redis.Int(c.Do("BITCOUNT", "foo", p.s, p.e))
-				ok(t, err)
-				equals(t, p.res, v)
-			}
-		}
+		test(0, 0, 3)  // "a"
+		test(0, 3, 13) // "abcd"
+		test(2, -2, 4) // "c"
 	}
 
 	// Wrong type of existing key

--- a/keys_test.go
+++ b/keys_test.go
@@ -7,117 +7,117 @@ import (
 func TestKeysSel(t *testing.T) {
 	// Helper to test the selection behind KEYS
 	// pattern -> cases -> should match?
-	for pat, chk := range map[string]map[string]bool{
-		"aap": {
-			"aap":         true,
-			"aapnoot":     false,
-			"nootaap":     false,
-			"nootaapnoot": false,
-			"AAP":         false,
-		},
-		"aap*": {
-			"aap":         true,
-			"aapnoot":     true,
-			"nootaap":     false,
-			"nootaapnoot": false,
-			"AAP":         false,
-		},
-		// No problem with regexp meta chars?
-		"(?:a)ap*": {
-			"(?:a)ap!": true,
-			"aap":      false,
-		},
-		"*aap*": {
-			"aap":         true,
-			"aapnoot":     true,
-			"nootaap":     true,
-			"nootaapnoot": true,
-			"AAP":         false,
-			"a_a_p":       false,
-		},
-		`\*aap*`: {
-			"*aap":     true,
-			"aap":      false,
-			"*aapnoot": true,
-			"aapnoot":  false,
-		},
-		`aa?`: {
-			"aap":  true,
-			"aal":  true,
-			"aaf":  true,
-			"aa?":  true,
-			"aap!": false,
-		},
-		`aa\?`: {
-			"aap":  false,
-			"aa?":  true,
-			"aa?!": false,
-		},
-		"aa[pl]": {
-			"aap":  true,
-			"aal":  true,
-			"aaf":  false,
-			"aa?":  false,
-			"aap!": false,
-		},
-		"[ab]a[pl]": {
-			"aap":  true,
-			"aal":  true,
-			"bap":  true,
-			"bal":  true,
-			"aaf":  false,
-			"cap":  false,
-			"aa?":  false,
-			"aap!": false,
-		},
-		`\[ab\]`: {
-			"[ab]": true,
-			"a":    false,
-		},
-		`[\[ab]`: {
-			"[": true,
-			"a": true,
-			"b": true,
-			"c": false,
-			"]": false,
-		},
-		`[\[\]]`: {
-			"[": true,
-			"]": true,
-			"c": false,
-		},
-		`\\ap`: {
-			`\ap`:  true,
-			`\\ap`: false,
-		},
-		// Escape a normal char
-		`\foo`: {
-			`foo`:  true,
-			`\foo`: false,
-		},
-	} {
+	test := func(pat string, chk map[string]bool) {
+		t.Helper()
 		patRe := patternRE(pat)
 		if patRe == nil {
-			t.Errorf("'%v' won't match anything. Didn't expect that.\n", pat)
-			continue
+			t.Errorf("'%v' won't match anything. Didn't expect that.", pat)
+			return
 		}
 		for key, expected := range chk {
 			match := patRe.MatchString(key)
-			if expected != match {
-				t.Errorf("'%v' -> '%v'. Matches %v, should %v\n", pat, key, match, expected)
+			if have, want := match, expected; have != want {
+				t.Errorf("'%v' -> '%v'. have %v, want %v", pat, key, have, want)
 			}
 		}
 	}
+	test("aap", map[string]bool{
+		"aap":         true,
+		"aapnoot":     false,
+		"nootaap":     false,
+		"nootaapnoot": false,
+		"AAP":         false,
+	})
+	test("aap*", map[string]bool{
+		"aap":         true,
+		"aapnoot":     true,
+		"nootaap":     false,
+		"nootaapnoot": false,
+		"AAP":         false,
+	})
+	// No problem with regexp meta chars?
+	test("(?:a)ap*", map[string]bool{
+		"(?:a)ap!": true,
+		"aap":      false,
+	})
+	test("*aap*", map[string]bool{
+		"aap":         true,
+		"aapnoot":     true,
+		"nootaap":     true,
+		"nootaapnoot": true,
+		"AAP":         false,
+		"a_a_p":       false,
+	})
+	test(`\*aap*`, map[string]bool{
+		"*aap":     true,
+		"aap":      false,
+		"*aapnoot": true,
+		"aapnoot":  false,
+	})
+	test(`aa?`, map[string]bool{
+		"aap":  true,
+		"aal":  true,
+		"aaf":  true,
+		"aa?":  true,
+		"aap!": false,
+	})
+	test(`aa\?`, map[string]bool{
+		"aap":  false,
+		"aa?":  true,
+		"aa?!": false,
+	})
+	test("aa[pl]", map[string]bool{
+		"aap":  true,
+		"aal":  true,
+		"aaf":  false,
+		"aa?":  false,
+		"aap!": false,
+	})
+	test("[ab]a[pl]", map[string]bool{
+		"aap":  true,
+		"aal":  true,
+		"bap":  true,
+		"bal":  true,
+		"aaf":  false,
+		"cap":  false,
+		"aa?":  false,
+		"aap!": false,
+	})
+	test(`\[ab\]`, map[string]bool{
+		"[ab]": true,
+		"a":    false,
+	})
+	test(`[\[ab]`, map[string]bool{
+		"[": true,
+		"a": true,
+		"b": true,
+		"c": false,
+		"]": false,
+	})
+	test(`[\[\]]`, map[string]bool{
+		"[": true,
+		"]": true,
+		"c": false,
+	})
+	test(`\\ap`, map[string]bool{
+		`\ap`:  true,
+		`\\ap`: false,
+	})
+	// Escape a normal char
+	test(`\foo`, map[string]bool{
+		`foo`:  true,
+		`\foo`: false,
+	})
 
 	// Patterns which won't match anything.
-	for _, pat := range []string{
-		`ap[\`, // trailing \ in char class
-		`ap[`,  // open char class
-		`[]ap`, // empty char class
-		`ap\`,  // trailing \
-	} {
+	test2 := func(pat string) {
+		t.Helper()
 		if patternRE(pat) != nil {
-			t.Errorf("'%v' will match something. Didn't expect that.\n", pat)
+			t.Errorf("'%v' will match something. Didn't expect that.", pat)
 		}
 	}
+	test2(`ap[\`) // trailing \ in char class
+	test2(`ap[`)  // open char class
+	test2(`[]ap`) // empty char class
+	test2(`ap\`)  // trailing \
 }

--- a/test_test.go
+++ b/test_test.go
@@ -7,6 +7,7 @@ import (
 
 // assert fails the test if the condition is false.
 func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+	tb.Helper()
 	if !condition {
 		tb.Errorf(msg, v...)
 	}
@@ -14,6 +15,7 @@ func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
 
 // ok fails the test if an err is not nil.
 func ok(tb testing.TB, err error) {
+	tb.Helper()
 	if err != nil {
 		tb.Errorf("unexpected error: %s", err.Error())
 	}
@@ -21,6 +23,7 @@ func ok(tb testing.TB, err error) {
 
 // equals fails the test if exp is not equal to act.
 func equals(tb testing.TB, exp, act interface{}) {
+	tb.Helper()
 	if !reflect.DeepEqual(exp, act) {
 		tb.Errorf("expected: %#v got: %#v", exp, act)
 	}
@@ -28,6 +31,7 @@ func equals(tb testing.TB, exp, act interface{}) {
 
 // mustFail compares the error strings
 func mustFail(tb testing.TB, err error, want string) {
+	tb.Helper()
 	if err == nil {
 		tb.Errorf("expected an error, but got a nil")
 	}


### PR DESCRIPTION
Minimum Go version is now >=1.9.

Test errors now point to the exact line, which is not the case with table based tests.