### PR TITLE
Use the new redigo import path

### DIFF
--- a/cmd_connection_test.go
+++ b/cmd_connection_test.go
@@ -3,7 +3,7 @@ package miniredis
 import (
 	"testing"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func TestAuth(t *testing.T) {

--- a/cmd_generic_test.go
+++ b/cmd_generic_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 // Test EXPIRE. Keys with an expiration are called volatile in Redis parlance.

--- a/cmd_hash_test.go
+++ b/cmd_hash_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 // Test Hash.

--- a/cmd_list_test.go
+++ b/cmd_list_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func setup(t *testing.T) (*Miniredis, redis.Conn, func()) {

--- a/cmd_scripting_test.go
+++ b/cmd_scripting_test.go
@@ -3,7 +3,7 @@ package miniredis
 import (
 	"testing"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func TestEval(t *testing.T) {

--- a/cmd_server_test.go
+++ b/cmd_server_test.go
@@ -3,7 +3,7 @@ package miniredis
 import (
 	"testing"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 // Test DBSIZE, FLUSHDB, and FLUSHALL.

--- a/cmd_set_test.go
+++ b/cmd_set_test.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 // Test SADD / SMEMBERS.

--- a/cmd_sorted_set_test.go
+++ b/cmd_sorted_set_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 // Test ZADD / ZCARD / ZRANK / ZREVRANK.

--- a/cmd_string_test.go
+++ b/cmd_string_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 // Test simple GET/SET keys

--- a/cmd_transactions_test.go
+++ b/cmd_transactions_test.go
@@ -3,7 +3,7 @@ package miniredis
 import (
 	"testing"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func TestMulti(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func Example() {

--- a/lua.go
+++ b/lua.go
@@ -1,7 +1,7 @@
 package miniredis
 
 import (
-	redigo "github.com/garyburd/redigo/redis"
+	redigo "github.com/gomodule/redigo/redis"
 	"github.com/yuin/gopher-lua"
 
 	"github.com/alicebob/miniredis/server"

--- a/miniredis.go
+++ b/miniredis.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	redigo "github.com/garyburd/redigo/redis"
+	redigo "github.com/gomodule/redigo/redis"
 
 	"github.com/alicebob/miniredis/server"
 )

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 // Test starting/stopping a server


### PR DESCRIPTION
The repository at github.com/garyburd is now a readonly snapshot of
v1.6.0. The 2.0.0 version bump seems to only be about reflecting the new
repository location in the internal import paths.