### PR TITLE
ignore `redis.replicate_commands()` call

### DIFF
--- a/cmd_scripting_test.go
+++ b/cmd_scripting_test.go
@@ -524,3 +524,15 @@ func TestCmdEvalAuth(t *testing.T) {
 	_, err = c.Do("EVAL", eval, 0)
 	ok(t, err)
 }
+
+func TestLuaReplicate(t *testing.T) {
+	s, err := Run()
+	ok(t, err)
+	defer s.Close()
+	c, err := redis.Dial("tcp", s.Addr())
+	ok(t, err)
+	defer c.Close()
+
+	_, err = c.Do("EVAL", "redis.replicate_commands()", 0)
+	ok(t, err)
+}

--- a/integration/script_test.go
+++ b/integration/script_test.go
@@ -287,3 +287,11 @@ func TestScriptNoAuth(t *testing.T) {
 		),
 	)
 }
+
+func TestScriptReplicate(t *testing.T) {
+	testCommands(t,
+		succ(
+			"EVAL", `redis.replicate_commands();`, 0,
+		),
+	)
+}

--- a/lua.go
+++ b/lua.go
@@ -94,6 +94,10 @@ func mkLuaFuncs(conn redigo.Conn) map[string]lua.LGFunction {
 			l.Push(lua.LString(sha1Hex(msg)))
 			return 1
 		},
+		"replicate_commands": func(l *lua.LState) int {
+			// ignored
+			return 1
+		},
 	}
 }
 


### PR DESCRIPTION
The function takes no arguments, so it's simple.

For #44.