### PR TITLE
update the "no such command" error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Commands which will probably not be implemented:
 
 ## &c.
 
-Tests are run against Redis 4.0.6 (Debian). The [./integration](./integration/)
+Tests are run against Redis 4.0.11 (Debian). The [./integration](./integration/)
 subdir compares miniredis against a real redis instance.
 
 

--- a/integration/generic_test.go
+++ b/integration/generic_test.go
@@ -64,10 +64,10 @@ func TestRandom(t *testing.T) {
 }
 
 func TestUnknownCommand(t *testing.T) {
-	// Can't compare; we get a different message from redeo
 	testCommands(t,
-		fail("nosuch"), // redeo doesn't change the capitilization, Redis lowercases it.
-		succ("SET", "foo", "bar"),
+		fail("nosuch"),
+		fail("noSUCH"),
+		fail("noSUCH", 1, 2, 3),
 	)
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -87,7 +87,7 @@ func Test(t *testing.T) {
 
 	{
 		_, err := c.Do("NOSUCH")
-		if have, want := err.Error(), "ERR unknown command 'nosuch'"; have != want {
+		if have, want := err.Error(), "ERR unknown command `NOSUCH`, with args beginning with: "; have != want {
 			t.Errorf("have: %s, want: %s", have, want)
 		}
 	}


### PR DESCRIPTION
It changed in Redis recently.