### PR TITLE
TIME command returns timestamp in string format

### DIFF
--- a/cmd_server.go
+++ b/cmd_server.go
@@ -97,7 +97,7 @@ func (m *Miniredis) cmdTime(c *server.Peer, cmd string, args []string) {
 		microseconds := (nanos / 1000) % 1000000
 
 		c.WriteLen(2)
-		c.WriteInt(int(seconds))
-		c.WriteInt(int(microseconds))
+		c.WriteBulk(strconv.FormatInt(seconds, 10))
+		c.WriteBulk(strconv.FormatInt(microseconds,10))
 	})
 }


### PR DESCRIPTION
Verified with both a 4.0.5 and 5.0.3 redis server. TIME command returns a bulk string instead of an INT. The go-redis timeParser explicitly parses results from TimeCmd this way. 