### PR TITLE
Fix SINTER for when keys do not exist

### DIFF
--- a/cmd_set_test.go
+++ b/cmd_set_test.go
@@ -507,6 +507,13 @@ func TestSinter(t *testing.T) {
 		equals(t, []string{}, els)
 	}
 
+	// With one of the keys being an empty set, the resulting set is also empty
+	{
+		els, err := redis.Strings(c.Do("SINTER", "s1", "s9"))
+		ok(t, err)
+		equals(t, []string{}, els)
+	}
+
 	// Various errors
 	{
 		s.SetAdd("chk", "aap", "noot")
@@ -539,6 +546,14 @@ func TestSinterstore(t *testing.T) {
 		ok(t, err)
 		equals(t, 2, i)
 		s.CheckSet(t, "res", "aap", "mies")
+	}
+
+	// With one of the keys being an empty set, the resulting set is also empty
+	{
+		i, err := redis.Int(c.Do("SINTERSTORE", "res", "s1", "s9"))
+		ok(t, err)
+		equals(t, 0, i)
+		s.CheckSet(t, "res", []string{}...)
 	}
 
 	// Various errors

--- a/db.go
+++ b/db.go
@@ -490,7 +490,7 @@ func (db *RedisDB) setInter(keys []string) (setKey, error) {
 	}
 	for _, sk := range keys {
 		if !db.exists(sk) {
-			continue
+			return setKey{}, nil
 		}
 		if db.t(sk) != "set" {
 			// Bug(?) in redis 2.8.14, it just skips the key.

--- a/db.go
+++ b/db.go
@@ -481,7 +481,10 @@ func (db *RedisDB) setDiff(keys []string) (setKey, error) {
 func (db *RedisDB) setInter(keys []string) (setKey, error) {
 	key := keys[0]
 	keys = keys[1:]
-	if db.exists(key) && db.t(key) != "set" {
+	if !db.exists(key) {
+		return setKey{}, nil
+	}
+	if db.t(key) != "set" {
 		return nil, ErrWrongType
 	}
 	s := setKey{}
@@ -493,9 +496,7 @@ func (db *RedisDB) setInter(keys []string) (setKey, error) {
 			return setKey{}, nil
 		}
 		if db.t(sk) != "set" {
-			// Bug(?) in redis 2.8.14, it just skips the key.
-			continue
-			// return nil, ErrWrongType
+			return nil, ErrWrongType
 		}
 		other := db.setKeys[sk]
 		for e := range s {

--- a/integration/set_test.go
+++ b/integration/set_test.go
@@ -208,15 +208,15 @@ func TestSetSdiff(t *testing.T) {
 
 func TestSetSinter(t *testing.T) {
 	testCommands(t,
-		succ("SINTER", "s1", "aap", "noot", "mies"),
-		succ("SINTER", "s2", "noot", "mies", "vuur"),
-		succ("SINTER", "s3", "mies", "wim"),
-		succ("SINTER", "s1"),
-		succ("SINTER", "s1", "s2"),
-		succ("SINTER", "s1", "s2", "s3"),
+		succ("SADD", "s1", "aap", "noot", "mies"),
+		succ("SADD", "s2", "noot", "mies", "vuur"),
+		succ("SADD", "s3", "mies", "wim"),
+		succSorted("SINTER", "s1"),
+		succSorted("SINTER", "s1", "s2"),
+		succSorted("SINTER", "s1", "s2", "s3"),
 		succ("SINTER", "nosuch"),
 		succ("SINTER", "s1", "nosuch", "s2", "nosuch", "s3"),
-		succ("SINTER", "s1", "s1"),
+		succSorted("SINTER", "s1", "s1"),
 
 		succ("SINTERSTORE", "res", "s3", "nosuch", "s1"),
 		succ("SMEMBERS", "res"),
@@ -227,11 +227,12 @@ func TestSetSinter(t *testing.T) {
 		fail("SINTERSTORE", "key"),
 		// Wrong type
 		succ("SET", "str", "I am a string"),
-		succ("SINTER", "s1", "str"),     // !
-		succ("SINTER", "nosuch", "str"), // !
+		fail("SINTER", "s1", "str"),
+		succ("SINTER", "nosuch", "str"), // SINTER succeeds if an input type is wrong as long as the preceding inputs result in an empty set
+		fail("SINTER", "str", "nosuch"),
 		fail("SINTER", "str", "s1"),
 		fail("SINTERSTORE", "res", "str", "s1"),
-		succ("SINTERSTORE", "res", "s1", "str"), // !
+		fail("SINTERSTORE", "res", "s1", "str"),
 	)
 }
 


### PR DESCRIPTION
[SINTER](https://redis.io/commands/sinter) considers keys that do not exist to be empty sets. This PR fixes https://github.com/alicebob/miniredis/issues/67.