### PR TITLE
fix PEXPIREAT and add test

### DIFF
--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -71,7 +71,7 @@ func makeCmdExpire(m *Miniredis, unix bool, d time.Duration) func(*server.Peer, 
 				var ts time.Time
 				switch d {
 				case time.Millisecond:
-					ts = time.Unix(0, int64(i))
+					ts = time.Unix(int64(i/1000), 1000000*int64(i%1000))
 				case time.Second:
 					ts = time.Unix(int64(i), 0)
 				default:


### PR DESCRIPTION
Input is in ms, but second agrument of time.Unix is ns.
Also seconds are filled separately to avoid int64 overflow
in year 2262.