### PR TITLE
Use internal rand.Rand with math/rand fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Implemented commands:
    - PTTL
    - RENAME
    - RENAMENX
-   - RANDOMKEY -- call math.rand.Seed(...) once before using.
+   - RANDOMKEY -- see m.Seed(...)
    - TTL
    - TYPE
    - SCAN
@@ -144,8 +144,8 @@ Implemented commands:
    - SISMEMBER
    - SMEMBERS
    - SMOVE
-   - SPOP -- call math.rand.Seed(...) once before using.
-   - SRANDMEMBER -- call math.rand.Seed(...) once before using.
+   - SPOP -- see m.Seed(...)
+   - SRANDMEMBER -- see m.Seed(...)
    - SREM
    - SUNION
    - SUNIONSTORE
@@ -197,6 +197,14 @@ which case time.Now() will be used.
 
 SetTime() also sets the value returned by TIME, which defaults to time.Now().
 It is not updated by FastForward, only by SetTime.
+
+## Randomness and Seed()
+
+Miniredis will use `math/rand`'s global RNG for randomness unless a seed is
+provided by calling `m.Seed(...)`. If a seed is provided, then miniredis will
+use its own RNG based on that seed.
+
+Commands which use randomness are: RANDOMKEY, SPOP, and SRANDMEMBER.
 
 ## Example
 

--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -3,7 +3,6 @@
 package miniredis
 
 import (
-	"math/rand"
 	"strconv"
 	"strings"
 	"time"
@@ -364,7 +363,7 @@ func (m *Miniredis) cmdRandomkey(c *server.Peer, cmd string, args []string) {
 			c.WriteNull()
 			return
 		}
-		nr := rand.Intn(len(db.keys))
+		nr := m.randIntn(len(db.keys))
 		for k := range db.keys {
 			if nr == 0 {
 				c.WriteBulk(k)

--- a/cmd_set.go
+++ b/cmd_set.go
@@ -3,7 +3,6 @@
 package miniredis
 
 import (
-	"math/rand"
 	"strconv"
 	"strings"
 
@@ -395,7 +394,7 @@ func (m *Miniredis) cmdSpop(c *server.Peer, cmd string, args []string) {
 			if len(members) == 0 {
 				break
 			}
-			member := members[rand.Intn(len(members))]
+			member := members[m.randIntn(len(members))]
 			db.setRem(key, member)
 			deleted = append(deleted, member)
 		}
@@ -467,7 +466,7 @@ func (m *Miniredis) cmdSrandmember(c *server.Peer, cmd string, args []string) {
 			// Non-unique elements is allowed with negative count.
 			c.WriteLen(-count)
 			for count != 0 {
-				member := members[rand.Intn(len(members))]
+				member := members[m.randIntn(len(members))]
 				c.WriteBulk(member)
 				count++
 			}
@@ -475,7 +474,7 @@ func (m *Miniredis) cmdSrandmember(c *server.Peer, cmd string, args []string) {
 		}
 
 		// Must be unique elements.
-		shuffle(members)
+		m.shuffle(members)
 		if count > len(members) {
 			count = len(members)
 		}
@@ -672,13 +671,4 @@ func (m *Miniredis) cmdSscan(c *server.Peer, cmd string, args []string) {
 			c.WriteBulk(k)
 		}
 	})
-}
-
-// shuffle shuffles a string. Kinda.
-func shuffle(m []string) {
-	for _ = range m {
-		i := rand.Intn(len(m))
-		j := rand.Intn(len(m))
-		m[i], m[j] = m[j], m[i]
-	}
 }

--- a/miniredis.go
+++ b/miniredis.go
@@ -16,6 +16,7 @@ package miniredis
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"strconv"
 	"sync"
@@ -56,6 +57,7 @@ type Miniredis struct {
 	signal      *sync.Cond
 	now         time.Time // used to make a duration from EXPIREAT. time.Now() if not set.
 	subscribers map[*Subscriber]struct{}
+	rand        *rand.Rand
 }
 
 type txCmd func(*server.Peer, *connCtx)
@@ -493,4 +495,28 @@ func (m *Miniredis) allSubscribers() []*Subscriber {
 		subs = append(subs, s)
 	}
 	return subs
+}
+
+func (m *Miniredis) Seed(seed int) {
+	m.Lock()
+	defer m.Unlock()
+
+	// m.rand is not safe for concurrent use.
+	m.rand = rand.New(rand.NewSource(int64(seed)))
+}
+
+func (m *Miniredis) randIntn(n int) int {
+	if m.rand == nil {
+		return rand.Intn(n)
+	}
+	return m.rand.Intn(n)
+}
+
+// shuffle shuffles a string. Kinda.
+func (m *Miniredis) shuffle(l []string) {
+	for range l {
+		i := m.randIntn(len(l))
+		j := m.randIntn(len(l))
+		l[i], l[j] = l[j], l[i]
+	}
 }


### PR DESCRIPTION
For #83.

This is an alternate solution which preserves the old global rand behavior (versus relying on the int given by a `rand.Int63` call.

Missing tests, but existing pass.

Arguably `shuffle` should have been `rand.Shuffle`, but the algorithm it uses (Fisher-Yates) is not the same as what `shuffle` did, so would result in changed behavior.

Redo of #88 (~~since I accidentally opened the PR to the wrong branch and I don't have permission to change that after submitting~~). Actually, I could have changed it, but it was hidden in the title change GUI... oops.