### PR TITLE
Fixes issue with ttl for a key being set to 0 in a rename when source key does not have a ttl

### DIFF
--- a/db.go
+++ b/db.go
@@ -88,7 +88,10 @@ func (db *RedisDB) rename(from, to string) {
 	}
 	db.keys[to] = db.keys[from]
 	db.keyVersion[to]++
-	db.ttl[to] = db.ttl[from]
+
+	if v, ok := db.ttl[from]; ok {
+		db.ttl[to] = v
+	}
 
 	db.del(from, true)
 }


### PR DESCRIPTION
Discovered this issue in my own unit tests. When using rename on a key that did not have an expiry set, FastForward was expiring the keys. 

Problem was because the ttl was being copied by doing db.ttl[to] = db.ttl[from]. Even if from did not exist, expiry was being set to 0 and thus, moving forward by any amount was causing non expiring keys to expire.