### PR TITLE
Report Null on aborted transaction

### DIFF
--- a/cmd_transactions.go
+++ b/cmd_transactions.go
@@ -76,7 +76,7 @@ func (m *Miniredis) cmdExec(c *server.Peer, cmd string, args []string) {
 		if m.db(t.db).keyVersion[t.key] > version {
 			// Abort! Abort!
 			stopTx(ctx)
-			c.WriteLen(0)
+			c.WriteNull()
 			return
 		}
 	}

--- a/cmd_transactions_test.go
+++ b/cmd_transactions_test.go
@@ -208,9 +208,8 @@ func TestTxWatchErr(t *testing.T) {
 	ok(t, err)
 	equals(t, "QUEUED", b)
 
-	v, err := redis.Values(c.Do("EXEC"))
-	ok(t, err)
-	equals(t, 0, len(v))
+	_, err = redis.Values(c.Do("EXEC"))
+	equals(t, err, redis.ErrNil)
 
 	// It did get updated, and we're not in a transaction anymore.
 	b, err = redis.String(c.Do("GET", "one"))


### PR DESCRIPTION
The documentation at https://redis.io/commands/exec states

    When using WATCH, EXEC can return a Null reply if the execution
    was aborted.

Redis returns Null in this case, and some clients in the wild expect
Null to signal that a transaction was aborted and behave poorly if
that is not the case.

This commit changes to be consistent with redis.

Fixes #94.