### PR TITLE
wakeup blocked calls during direct access

### DIFF
--- a/cmd_list_test.go
+++ b/cmd_list_test.go
@@ -76,6 +76,18 @@ func TestLpush(t *testing.T) {
 		equals(t, false, s.Exists("l2"))
 	})
 
+	t.Run("direct, wakeup", func(t *testing.T) {
+		go func() {
+			time.Sleep(30 * time.Millisecond)
+			l, err := s.Lpush("q1", "a")
+			ok(t, err)
+			equals(t, 1, l)
+		}()
+
+		v, err := redis.String(c.Do("BRPOPLPUSH", "q1", "q2", "1"))
+		ok(t, err)
+		equals(t, "a", v)
+	})
 
 	t.Run("errors", func(t *testing.T) {
 		_, err := redis.Int(c.Do("LPUSH"))

--- a/cmd_list_test.go
+++ b/cmd_list_test.go
@@ -29,7 +29,7 @@ func TestLpush(t *testing.T) {
 	s, c, done := setup(t)
 	defer done()
 
-	{
+	t.Run("basic", func(t *testing.T) {
 		b, err := redis.Int(c.Do("LPUSH", "l", "aap", "noot", "mies"))
 		ok(t, err)
 		equals(t, 3, b) // New length.
@@ -41,25 +41,21 @@ func TestLpush(t *testing.T) {
 		r, err = redis.Strings(c.Do("LRANGE", "l", "-1", "-1"))
 		ok(t, err)
 		equals(t, []string{"aap"}, r)
-	}
 
-	// Push more.
-	{
-		b, err := redis.Int(c.Do("LPUSH", "l", "aap2", "noot2", "mies2"))
+		b, err = redis.Int(c.Do("LPUSH", "l", "aap2", "noot2", "mies2"))
 		ok(t, err)
 		equals(t, 6, b) // New length.
 
-		r, err := redis.Strings(c.Do("LRANGE", "l", "0", "0"))
+		r, err = redis.Strings(c.Do("LRANGE", "l", "0", "0"))
 		ok(t, err)
 		equals(t, []string{"mies2"}, r)
 
 		r, err = redis.Strings(c.Do("LRANGE", "l", "-1", "-1"))
 		ok(t, err)
 		equals(t, []string{"aap"}, r)
-	}
+	})
 
-	// Direct usage
-	{
+	t.Run("direct", func(t *testing.T) {
 		l, err := s.Lpush("l2", "a")
 		ok(t, err)
 		equals(t, 1, l)
@@ -78,10 +74,10 @@ func TestLpush(t *testing.T) {
 		equals(t, "a", el)
 		// Key is removed on pop-empty.
 		equals(t, false, s.Exists("l2"))
-	}
+	})
 
-	// Various errors
-	{
+
+	t.Run("errors", func(t *testing.T) {
 		_, err := redis.Int(c.Do("LPUSH"))
 		assert(t, err != nil, "LPUSH error")
 		_, err = redis.Int(c.Do("LPUSH", "l"))
@@ -90,8 +86,7 @@ func TestLpush(t *testing.T) {
 		ok(t, err)
 		_, err = redis.Int(c.Do("LPUSH", "str", "noot", "mies"))
 		assert(t, err != nil, "LPUSH error")
-	}
-
+	})
 }
 
 func TestLpushx(t *testing.T) {

--- a/direct.go
+++ b/direct.go
@@ -37,6 +37,7 @@ func (m *Miniredis) Keys() []string {
 func (db *RedisDB) Keys() []string {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	return db.allKeys()
 }
 
@@ -44,6 +45,8 @@ func (db *RedisDB) Keys() []string {
 func (m *Miniredis) FlushAll() {
 	m.Lock()
 	defer m.Unlock()
+	defer m.signal.Broadcast()
+
 	m.flushAll()
 }
 
@@ -62,6 +65,8 @@ func (m *Miniredis) FlushDB() {
 func (db *RedisDB) FlushDB() {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
+
 	db.flush()
 }
 
@@ -74,6 +79,7 @@ func (m *Miniredis) Get(k string) (string, error) {
 func (db *RedisDB) Get(k string) (string, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	if !db.exists(k) {
 		return "", ErrKeyNotFound
 	}
@@ -93,6 +99,7 @@ func (m *Miniredis) Set(k, v string) error {
 func (db *RedisDB) Set(k, v string) error {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
 
 	if db.exists(k) && db.t(k) != "string" {
 		return ErrWrongType
@@ -111,6 +118,7 @@ func (m *Miniredis) Incr(k string, delta int) (int, error) {
 func (db *RedisDB) Incr(k string, delta int) (int, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
 
 	if db.exists(k) && db.t(k) != "string" {
 		return 0, ErrWrongType
@@ -128,6 +136,7 @@ func (m *Miniredis) Incrfloat(k string, delta float64) (float64, error) {
 func (db *RedisDB) Incrfloat(k string, delta float64) (float64, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
 
 	if db.exists(k) && db.t(k) != "string" {
 		return 0, ErrWrongType
@@ -168,6 +177,7 @@ func (m *Miniredis) Lpush(k, v string) (int, error) {
 func (db *RedisDB) Lpush(k, v string) (int, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
 
 	if db.exists(k) && db.t(k) != "list" {
 		return 0, ErrWrongType
@@ -184,6 +194,7 @@ func (m *Miniredis) Lpop(k string) (string, error) {
 func (db *RedisDB) Lpop(k string) (string, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
 
 	if !db.exists(k) {
 		return "", ErrKeyNotFound
@@ -203,6 +214,7 @@ func (m *Miniredis) Push(k string, v ...string) (int, error) {
 func (db *RedisDB) Push(k string, v ...string) (int, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
 
 	if db.exists(k) && db.t(k) != "list" {
 		return 0, ErrWrongType
@@ -219,6 +231,7 @@ func (m *Miniredis) Pop(k string) (string, error) {
 func (db *RedisDB) Pop(k string) (string, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
 
 	if !db.exists(k) {
 		return "", ErrKeyNotFound
@@ -239,6 +252,8 @@ func (m *Miniredis) SetAdd(k string, elems ...string) (int, error) {
 func (db *RedisDB) SetAdd(k string, elems ...string) (int, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
+
 	if db.exists(k) && db.t(k) != "set" {
 		return 0, ErrWrongType
 	}
@@ -254,6 +269,7 @@ func (m *Miniredis) Members(k string) ([]string, error) {
 func (db *RedisDB) Members(k string) ([]string, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	if !db.exists(k) {
 		return nil, ErrKeyNotFound
 	}
@@ -272,6 +288,7 @@ func (m *Miniredis) IsMember(k, v string) (bool, error) {
 func (db *RedisDB) IsMember(k, v string) (bool, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	if !db.exists(k) {
 		return false, ErrKeyNotFound
 	}
@@ -290,6 +307,7 @@ func (m *Miniredis) HKeys(k string) ([]string, error) {
 func (db *RedisDB) HKeys(key string) ([]string, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	if !db.exists(key) {
 		return nil, ErrKeyNotFound
 	}
@@ -308,6 +326,8 @@ func (m *Miniredis) Del(k string) bool {
 func (db *RedisDB) Del(k string) bool {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
+
 	if !db.exists(k) {
 		return false
 	}
@@ -328,6 +348,7 @@ func (m *Miniredis) TTL(k string) time.Duration {
 func (db *RedisDB) TTL(k string) time.Duration {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	return db.ttl[k]
 }
 
@@ -340,6 +361,8 @@ func (m *Miniredis) SetTTL(k string, ttl time.Duration) {
 func (db *RedisDB) SetTTL(k string, ttl time.Duration) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
+
 	db.ttl[k] = ttl
 	db.keyVersion[k]++
 }
@@ -353,6 +376,7 @@ func (m *Miniredis) Type(k string) string {
 func (db *RedisDB) Type(k string) string {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	return db.t(k)
 }
 
@@ -365,6 +389,7 @@ func (m *Miniredis) Exists(k string) bool {
 func (db *RedisDB) Exists(k string) bool {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	return db.exists(k)
 }
 
@@ -381,6 +406,7 @@ func (m *Miniredis) HGet(k, f string) string {
 func (db *RedisDB) HGet(k, f string) string {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	h, ok := db.hashKeys[k]
 	if !ok {
 		return ""
@@ -399,6 +425,8 @@ func (m *Miniredis) HSet(k, f, v string) {
 func (db *RedisDB) HSet(k, f, v string) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
+
 	db.hashSet(k, f, v)
 }
 
@@ -411,6 +439,8 @@ func (m *Miniredis) HDel(k, f string) {
 func (db *RedisDB) HDel(k, f string) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
+
 	db.hdel(k, f)
 }
 
@@ -431,6 +461,8 @@ func (m *Miniredis) HIncr(k, f string, delta int) (int, error) {
 func (db *RedisDB) HIncr(k, f string, delta int) (int, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
+
 	return db.hashIncr(k, f, delta)
 }
 
@@ -443,6 +475,8 @@ func (m *Miniredis) HIncrfloat(k, f string, delta float64) (float64, error) {
 func (db *RedisDB) HIncrfloat(k, f string, delta float64) (float64, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
+
 	return db.hashIncrfloat(k, f, delta)
 }
 
@@ -455,6 +489,8 @@ func (m *Miniredis) SRem(k string, fields ...string) (int, error) {
 func (db *RedisDB) SRem(k string, fields ...string) (int, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
+
 	if !db.exists(k) {
 		return 0, ErrKeyNotFound
 	}
@@ -473,6 +509,8 @@ func (m *Miniredis) ZAdd(k string, score float64, member string) (bool, error) {
 func (db *RedisDB) ZAdd(k string, score float64, member string) (bool, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
+
 	if db.exists(k) && db.t(k) != "zset" {
 		return false, ErrWrongType
 	}
@@ -488,6 +526,7 @@ func (m *Miniredis) ZMembers(k string) ([]string, error) {
 func (db *RedisDB) ZMembers(k string) ([]string, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	if !db.exists(k) {
 		return nil, ErrKeyNotFound
 	}
@@ -506,6 +545,7 @@ func (m *Miniredis) SortedSet(k string) (map[string]float64, error) {
 func (db *RedisDB) SortedSet(k string) (map[string]float64, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	if !db.exists(k) {
 		return nil, ErrKeyNotFound
 	}
@@ -524,6 +564,8 @@ func (m *Miniredis) ZRem(k, member string) (bool, error) {
 func (db *RedisDB) ZRem(k, member string) (bool, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+	defer db.master.signal.Broadcast()
+
 	if !db.exists(k) {
 		return false, ErrKeyNotFound
 	}
@@ -542,6 +584,7 @@ func (m *Miniredis) ZScore(k, member string) (float64, error) {
 func (db *RedisDB) ZScore(k, member string) (float64, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
+
 	if !db.exists(k) {
 		return 0, ErrKeyNotFound
 	}
@@ -555,6 +598,7 @@ func (db *RedisDB) ZScore(k, member string) (float64, error) {
 func (m *Miniredis) Publish(channel, message string) int {
 	m.Lock()
 	defer m.Unlock()
+
 	return m.publish(channel, message)
 }
 

--- a/direct.go
+++ b/direct.go
@@ -10,10 +10,13 @@ import (
 var (
 	// ErrKeyNotFound is returned when a key doesn't exist.
 	ErrKeyNotFound = errors.New(msgKeyNotFound)
+
 	// ErrWrongType when a key is not the right type.
 	ErrWrongType = errors.New(msgWrongType)
+
 	// ErrIntValueError can returned by INCRBY
 	ErrIntValueError = errors.New(msgInvalidInt)
+
 	// ErrFloatValueError can returned by INCRBYFLOAT
 	ErrFloatValueError = errors.New(msgInvalidFloat)
 )

--- a/miniredis.go
+++ b/miniredis.go
@@ -33,7 +33,7 @@ type setKey map[string]struct{}
 
 // RedisDB holds a single (numbered) Redis database.
 type RedisDB struct {
-	master        *sync.Mutex              // pointer to the lock in Miniredis
+	master        *Miniredis               // pointer to the lock in Miniredis
 	id            int                      // db id
 	keys          map[string]string        // Master map of keys with their type
 	stringKeys    map[string]string        // GET/SET &c. keys
@@ -89,10 +89,10 @@ func NewMiniRedis() *Miniredis {
 	return &m
 }
 
-func newRedisDB(id int, l *sync.Mutex) RedisDB {
+func newRedisDB(id int, m *Miniredis) RedisDB {
 	return RedisDB{
 		id:            id,
-		master:        l,
+		master:        m,
 		keys:          map[string]string{},
 		stringKeys:    map[string]string{},
 		hashKeys:      map[string]hashKey{},
@@ -194,7 +194,7 @@ func (m *Miniredis) db(i int) *RedisDB {
 	if db, ok := m.dbs[i]; ok {
 		return db
 	}
-	db := newRedisDB(i, &m.Mutex) // the DB has our lock.
+	db := newRedisDB(i, m) // main miniredis has our mutex.
 	m.dbs[i] = &db
 	return &db
 }


### PR DESCRIPTION
Fixes #97 
the problem was that the "direct access" methods (such as `m.Lpush(...)`) did not wake up commands waiting for changes. Now they do.