### PR TITLE
ZRANGEBYLEX: Fix min resulting in empty set returning full set instead

### DIFF
--- a/cmd_sorted_set.go
+++ b/cmd_sorted_set.go
@@ -1125,10 +1125,12 @@ func withLexRange(members []string, min string, minIncl bool, max string, maxInc
 		return nil
 	}
 	if min != "-" {
+		found := false
 		if minIncl {
 			for i, m := range members {
 				if m >= min {
 					members = members[i:]
+					found = true
 					break
 				}
 			}
@@ -1137,9 +1139,13 @@ func withLexRange(members []string, min string, minIncl bool, max string, maxInc
 			for i, m := range members {
 				if m > min {
 					members = members[i:]
+					found = true
 					break
 				}
 			}
+		}
+		if !found {
+			return nil
 		}
 	}
 	if max != "+" {

--- a/cmd_sorted_set_test.go
+++ b/cmd_sorted_set_test.go
@@ -886,6 +886,10 @@ func TestSortedSetRangeByLex(t *testing.T) {
 			"zwei",
 		}, b)
 
+		b, err = redis.Strings(c.Do("ZRANGEBYLEX", "z", "[zz", "+"))
+		ok(t, err)
+		equals(t, []string{}, b)
+
 		b, err = redis.Strings(c.Do("ZREVRANGEBYLEX", "z", "+", "-"))
 		ok(t, err)
 		equals(t, []string{


### PR DESCRIPTION
If ZRANGEBYLEN was used with a Min that would result in an empty set, the break condition would never trigger so the full set would get returned instead.

Fixes #99