### PR TITLE
Allow custom command implementations

### DIFF
--- a/miniredis.go
+++ b/miniredis.go
@@ -273,6 +273,11 @@ func (m *Miniredis) FastForward(duration time.Duration) {
 	}
 }
 
+// Server returns the underlying server to allow custom commands to be implemented
+func (m *Miniredis) Server() *server.Server {
+	return m.srv
+}
+
 // redigo returns a redigo.Conn, connected using net.Pipe
 func (m *Miniredis) redigo() redigo.Conn {
 	c1, c2 := net.Pipe()


### PR DESCRIPTION
My specific scenario was the need to implement `INFO` and it seemed like this would be relatively easy to do if the underlying `Server.Register` was accessible.

In my private fork, I ended up exposing the `Server` like here.   If exposing the full Server object is too much, we could just proxy the Register() method.

Thoughts?
