### PR TITLE
use 128 bit floats internally

### DIFF
--- a/cmd_hash.go
+++ b/cmd_hash.go
@@ -3,6 +3,7 @@
 package miniredis
 
 import (
+	"math/big"
 	"strconv"
 	"strings"
 
@@ -498,7 +499,7 @@ func (m *Miniredis) cmdHincrbyfloat(c *server.Peer, cmd string, args []string) {
 
 	key, field, deltas := args[0], args[1], args[2]
 
-	delta, err := strconv.ParseFloat(deltas, 64)
+	delta, _, err := big.ParseFloat(deltas, 10, 128, 0)
 	if err != nil {
 		setDirty(c)
 		c.WriteError(msgInvalidFloat)
@@ -518,7 +519,7 @@ func (m *Miniredis) cmdHincrbyfloat(c *server.Peer, cmd string, args []string) {
 			c.WriteError(err.Error())
 			return
 		}
-		c.WriteBulk(formatFloat(v))
+		c.WriteBulk(formatBig(v))
 	})
 }
 

--- a/cmd_string.go
+++ b/cmd_string.go
@@ -3,6 +3,7 @@
 package miniredis
 
 import (
+	"math/big"
 	"strconv"
 	"strings"
 	"time"
@@ -504,7 +505,7 @@ func (m *Miniredis) cmdIncrbyfloat(c *server.Peer, cmd string, args []string) {
 	}
 
 	key := args[0]
-	delta, err := strconv.ParseFloat(args[1], 64)
+	delta, _, err := big.ParseFloat(args[1], 10, 128, 0)
 	if err != nil {
 		setDirty(c)
 		c.WriteError(msgInvalidFloat)
@@ -525,7 +526,7 @@ func (m *Miniredis) cmdIncrbyfloat(c *server.Peer, cmd string, args []string) {
 			return
 		}
 		// Don't touch TTL
-		c.WriteBulk(formatFloat(v))
+		c.WriteBulk(formatBig(v))
 	})
 }
 

--- a/direct.go
+++ b/direct.go
@@ -4,6 +4,7 @@ package miniredis
 
 import (
 	"errors"
+	"math/big"
 	"time"
 )
 
@@ -148,7 +149,12 @@ func (db *RedisDB) Incrfloat(k string, delta float64) (float64, error) {
 		return 0, ErrWrongType
 	}
 
-	return db.stringIncrfloat(k, delta)
+	v, err := db.stringIncrfloat(k, big.NewFloat(delta))
+	if err != nil {
+		return 0, err
+	}
+	vf, _ := v.Float64()
+	return vf, nil
 }
 
 // List returns the list k, or an error if it's not there or something else.
@@ -534,7 +540,12 @@ func (db *RedisDB) HIncrfloat(k, f string, delta float64) (float64, error) {
 	defer db.master.Unlock()
 	defer db.master.signal.Broadcast()
 
-	return db.hashIncrfloat(k, f, delta)
+	v, err := db.hashIncrfloat(k, f, big.NewFloat(delta))
+	if err != nil {
+		return 0, err
+	}
+	vf, _ := v.Float64()
+	return vf, nil
 }
 
 // SRem removes fields from a set. Returns number of deleted fields.

--- a/redis.go
+++ b/redis.go
@@ -3,6 +3,7 @@ package miniredis
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"strings"
 	"sync"
 	"time"
@@ -129,16 +130,28 @@ func blocking(
 
 // formatFloat formats a float the way redis does (sort-of)
 func formatFloat(v float64) string {
-	// Format with %f and strip trailing 0s. This is the most like Redis does
-	// it :(
-	// .12 is the magic number where most output is the same as Redis.
-	if math.IsInf(v, +1) {
+	if math.IsInf(v, 1) {
 		return "inf"
 	}
 	if math.IsInf(v, -1) {
 		return "-inf"
 	}
-	sv := fmt.Sprintf("%.12f", v)
+	return stripZeros(fmt.Sprintf("%.12f", v))
+}
+
+// formatBig formats a float the way redis does
+func formatBig(v *big.Float) string {
+	// Format with %f and strip trailing 0s.
+	if v.IsInf() {
+		return "inf"
+	}
+	// if math.IsInf(v, -1) {
+	// return "-inf"
+	// }
+	return stripZeros(fmt.Sprintf("%.17f", v))
+}
+
+func stripZeros(sv string) string {
 	for strings.Contains(sv, ".") {
 		if sv[len(sv)-1] != '0' {
 			break


### PR DESCRIPTION
Redis uses "long double"s, and formats this way. This seems to fix #17, in the way suggested there.

The big floats are not used in the sorted sets, which still use float64s.