### PR TITLE
Protect globals in lua scripts/eval

### DIFF
--- a/cmd_scripting_test.go
+++ b/cmd_scripting_test.go
@@ -1,6 +1,7 @@
 package miniredis
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gomodule/redigo/redis"
@@ -58,6 +59,16 @@ func TestEval(t *testing.T) {
 		b, err := redis.String(c.Do("EVAL", `return string.gsub("foo", "o", "a")`, 0))
 		ok(t, err)
 		equals(t, "faa", b)
+	}
+
+	_, err = c.Do("EVAL", "return someGlobal", 0)
+	if err == nil || !strings.Contains(err.Error(), "Script attempted to access nonexistent global variable 'someGlobal'") {
+		t.Error("unexpected error", err)
+	}
+
+	_, err = c.Do("EVAL", "someGlobal = 5", 0)
+	if err == nil || !strings.Contains(err.Error(), "Script attempted to create global variable 'someGlobal'") {
+		t.Error("unexpected error", err)
 	}
 }
 


### PR DESCRIPTION
Redis runs a version of the [strict.lua](http://metalua.luaforge.net/src/lib/strict.lua.html) script when it initializes the lua environment.  This catches bugs where globals are accidentally written or read from.

This change adds this functionality to miniredis.  The lua script used here is very close to the same one used by redis -- the difference is that a check for `main` is skipped here (because of differences in how the lua environment is loaded here vs redis).
