### PR TITLE
BLPOP does not stop blocking even when we close miniredis

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -124,6 +124,10 @@ func blocking(
 			m.signal.Broadcast() // to kill the wakeup go routine
 			wg.Wait()
 			return
+		case <-m.Ctx.Done():
+			m.signal.Broadcast() // to kill the wakeup go routine
+			wg.Wait()
+			return
 		}
 		wg.Wait()
 	}


### PR DESCRIPTION
Hey, this is actually an issue, but I figured it would be more useful to provide an easy-to-reproduce testcase, so here it is. Also, I'm trying to figure out a solution, please let me know if you have any hints!

In genera the problem is this:
I have a test in which I call `BLPop mykey 0` and then close the client(go-redis) as well as the miniredis and the testcase hangs. After some investigation it turned out that after calling `miniredis.Close()` miniredis does not actually close but wait on a waitgroup until all the clients are done working. Which is impossible in my case because my only client has been closed by me.

I ran `go test -count 1 -v -run TestBlpopResou ./` in the filetree root and the test hangs just like my real test.