### PR TITLE
Add support for multiple field/value pairs to HSET

### DIFF
--- a/cmd_hash.go
+++ b/cmd_hash.go
@@ -30,7 +30,7 @@ func commandsHash(m *Miniredis) {
 
 // HSET
 func (m *Miniredis) cmdHset(c *server.Peer, cmd string, args []string) {
-	if len(args) != 3 {
+	if len(args) < 3 || len(args)%2 == 0 {
 		setDirty(c)
 		c.WriteError(errWrongNumber(cmd))
 		return
@@ -42,7 +42,7 @@ func (m *Miniredis) cmdHset(c *server.Peer, cmd string, args []string) {
 		return
 	}
 
-	key, field, value := args[0], args[1], args[2]
+	key, pairs := args[0], args[1:]
 
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
@@ -52,11 +52,8 @@ func (m *Miniredis) cmdHset(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
-		if db.hashSet(key, field, value) {
-			c.WriteInt(0)
-		} else {
-			c.WriteInt(1)
-		}
+		new := db.hashSet(key, pairs...)
+		c.WriteInt(new)
 	})
 }
 

--- a/cmd_hash_test.go
+++ b/cmd_hash_test.go
@@ -35,12 +35,35 @@ func TestHash(t *testing.T) {
 		equals(t, 0, b) // Existing field.
 	}
 
+	{
+		b, err := redis.Int(c.Do("HSET", "aaa", "bbb", "cc", "ddd", "ee"))
+		ok(t, err)
+		equals(t, 2, b) // Multiple fields.
+	}
+
+	{
+		v1, err := redis.String(c.Do("HGET", "aaa", "bbb"))
+		ok(t, err)
+		equals(t, "cc", v1)
+		equals(t, "cc", s.HGet("aaa", "bbb"))
+		v2, err := redis.String(c.Do("HGET", "aaa", "ddd"))
+		ok(t, err)
+		equals(t, "ee", v2)
+		equals(t, "ee", s.HGet("aaa", "ddd"))
+	}
+
 	// Wrong type of key
 	{
 		_, err := redis.String(c.Do("SET", "foo", "bar"))
 		ok(t, err)
 		_, err = redis.Int(c.Do("HSET", "foo", "noot", "mies"))
 		assert(t, err != nil, "HSET error")
+	}
+
+	// HSET with unmatched pairs
+	{
+		_, err := redis.Int(c.Do("HSET", "a", "b", "c", "d"))
+		assert(t, err != nil, "HSET unmatched error")
 	}
 
 	// hash exists, key doesn't.
@@ -70,6 +93,17 @@ func TestHash(t *testing.T) {
 		v, err := redis.String(c.Do("HGET", "wim", "zus"))
 		ok(t, err)
 		equals(t, "jet", v)
+	}
+
+	// Direct HSet() multiple
+	{
+		s.HSet("xxx", "yyy", "a", "zzz", "b")
+		v1, err := redis.String(c.Do("HGET", "xxx", "yyy"))
+		ok(t, err)
+		equals(t, "a", v1)
+		v2, err := redis.String(c.Do("HGET", "xxx", "zzz"))
+		ok(t, err)
+		equals(t, "b", v2)
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -315,8 +315,8 @@ func (db *RedisDB) hashGet(key, field string) string {
 	return db.hashKeys[key][field]
 }
 
-// hashSet returns whether the key already existed
-func (db *RedisDB) hashSet(k, f, v string) bool {
+// hashSet returns the number of new keys
+func (db *RedisDB) hashSet(k string, fv ...string) int {
 	if t, ok := db.keys[k]; ok && t != "hash" {
 		db.del(k, true)
 	}
@@ -324,10 +324,17 @@ func (db *RedisDB) hashSet(k, f, v string) bool {
 	if _, ok := db.hashKeys[k]; !ok {
 		db.hashKeys[k] = map[string]string{}
 	}
-	_, ok := db.hashKeys[k][f]
-	db.hashKeys[k][f] = v
-	db.keyVersion[k]++
-	return ok
+	new := 0
+	for idx := 0; idx < len(fv)-1; idx = idx + 2 {
+		f, v := fv[idx], fv[idx+1]
+		_, ok := db.hashKeys[k][f]
+		db.hashKeys[k][f] = v
+		db.keyVersion[k]++
+		if !ok {
+			new++
+		}
+	}
+	return new
 }
 
 // hashIncr changes int key value

--- a/direct.go
+++ b/direct.go
@@ -467,20 +467,20 @@ func (db *RedisDB) HGet(k, f string) string {
 	return h[f]
 }
 
-// HSet sets a hash key.
+// HSet sets hash keys.
 // If there is another key by the same name it will be gone.
-func (m *Miniredis) HSet(k, f, v string) {
-	m.DB(m.selectedDB).HSet(k, f, v)
+func (m *Miniredis) HSet(k string, fv ...string) {
+	m.DB(m.selectedDB).HSet(k, fv...)
 }
 
-// HSet sets a hash key.
+// HSet sets hash keys.
 // If there is another key by the same name it will be gone.
-func (db *RedisDB) HSet(k, f, v string) {
+func (db *RedisDB) HSet(k string, fv ...string) {
 	db.master.Lock()
 	defer db.master.Unlock()
 	defer db.master.signal.Broadcast()
 
-	db.hashSet(k, f, v)
+	db.hashSet(k, fv...)
 }
 
 // HDel deletes a hash key.

--- a/integration/hash_test.go
+++ b/integration/hash_test.go
@@ -16,6 +16,9 @@ func TestHash(t *testing.T) {
 		succ("HLEN", "aap"),
 		succ("HKEYS", "aap"),
 		succ("HVALS", "aap"),
+		succ("HSET", "aaa", "bb", "1", "cc", "2"),
+		succ("HGET", "aaa", "bb"),
+		succ("HGET", "aaa", "cc"),
 
 		succ("HDEL", "aap", "noot"),
 		succ("HGET", "aap", "noot"),
@@ -35,6 +38,8 @@ func TestHash(t *testing.T) {
 		fail("HLEN", "str"),
 		fail("HKEYS", "str"),
 		fail("HVALS", "str"),
+		fail("HSET", "a1", "b"),
+		// fail("HSET", "a2", "b", "c", "d"), // TODO redis refers to HMSET
 	)
 }
 


### PR DESCRIPTION
Various changes required to allow HSET to handle multiple field value pairs. Closes #120.

One integration test (commented out) does not work as the error message from Redis does not match the expected one. Let me know if you want me want to get that sorted first?

This is my first pull request so hopefully I've done everything right.

