### PR TITLE
Support for TOUCH command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Implemented commands:
    - RENAMENX
    - RANDOMKEY -- see m.Seed(...)
    - SCAN
+   - TOUCH
    - TTL
    - TYPE
    - UNLINK

--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -31,6 +31,7 @@ func commandsGeneric(m *Miniredis) {
 	m.srv.Register("RENAMENX", m.cmdRenamenx)
 	// RESTORE
 	// SORT
+	m.srv.Register("TOUCH", m.cmdTouch)
 	m.srv.Register("TTL", m.cmdTTL)
 	m.srv.Register("TYPE", m.cmdType)
 	m.srv.Register("SCAN", m.cmdScan)
@@ -85,11 +86,41 @@ func makeCmdExpire(m *Miniredis, unix bool, d time.Duration) func(*server.Peer, 
 			} else {
 				db.ttl[key] = time.Duration(i) * d
 			}
+			db.origTtl[key] = db.ttl[key]
 			db.keyVersion[key]++
 			db.checkTTL(key)
 			c.WriteInt(1)
 		})
 	}
+}
+
+// TOUCH
+func (m *Miniredis) cmdTouch(c *server.Peer, cmd string, args []string) {
+	if !m.handleAuth(c) {
+		return
+	}
+	if m.checkPubsub(c) {
+		return
+	}
+
+	if len(args) == 0 {
+		setDirty(c)
+		c.WriteError(errWrongNumber(cmd))
+		return
+	}
+
+	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
+		db := m.db(ctx.selectedDB)
+
+		count := 0
+		for _, key := range args {
+			if db.exists(key) {
+				count++
+			}
+			db.touch(key)
+		}
+		c.WriteInt(count)
+	})
 }
 
 // TTL
@@ -192,6 +223,7 @@ func (m *Miniredis) cmdPersist(c *server.Peer, cmd string, args []string) {
 			c.WriteInt(0)
 			return
 		}
+		delete(db.origTtl, key)
 		delete(db.ttl, key)
 		db.keyVersion[key]++
 		c.WriteInt(1)

--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -116,8 +116,8 @@ func (m *Miniredis) cmdTouch(c *server.Peer, cmd string, args []string) {
 		for _, key := range args {
 			if db.exists(key) {
 				count++
+				db.touch(key)
 			}
-			db.touch(key)
 		}
 		c.WriteInt(count)
 	})

--- a/cmd_generic_test.go
+++ b/cmd_generic_test.go
@@ -168,16 +168,19 @@ func TestTouch(t *testing.T) {
 		ok(t, err)
 
 		// Touch one key
-		_, err = c.Do("TOUCH", "baz")
+		n, err := redis.Int(c.Do("TOUCH", "baz"))
 		ok(t, err)
+		equals(t, 1, n)
 
 		s.FastForward(time.Second * 99)
 		equals(t, time.Second*101, s.TTL("foo"))
 		equals(t, time.Second, s.TTL("baz"))
 
-		// Reset TTL on multiple keys
-		_, err = c.Do("TOUCH", "foo", "baz")
+		// Reset TTL on multiple keys, "nay" doesn't exist
+		n, err = redis.Int(c.Do("TOUCH", "foo", "baz", "nay"))
 		ok(t, err)
+		equals(t, 2, n)
+
 		equals(t, time.Second*200, s.TTL("foo"))
 		equals(t, time.Second*100, s.TTL("baz"))
 	}

--- a/cmd_string.go
+++ b/cmd_string.go
@@ -121,6 +121,7 @@ func (m *Miniredis) cmdSet(c *server.Peer, cmd string, args []string) {
 		// a vanilla SET clears the expire
 		db.stringSet(key, value)
 		if ttl != 0 {
+			db.origTtl[key] = ttl
 			db.ttl[key] = ttl
 		}
 		c.WriteOK()
@@ -161,6 +162,7 @@ func (m *Miniredis) cmdSetex(c *server.Peer, cmd string, args []string) {
 		db.del(key, true) // Clear any existing keys.
 		db.stringSet(key, value)
 		db.ttl[key] = time.Duration(ttl) * time.Second
+		db.origTtl[key] = db.ttl[key]
 		c.WriteOK()
 	})
 }
@@ -199,6 +201,7 @@ func (m *Miniredis) cmdPsetex(c *server.Peer, cmd string, args []string) {
 		db.del(key, true) // Clear any existing keys.
 		db.stringSet(key, value)
 		db.ttl[key] = time.Duration(ttl) * time.Millisecond
+		db.origTtl[key] = db.ttl[key]
 		c.WriteOK()
 	})
 }
@@ -374,6 +377,7 @@ func (m *Miniredis) cmdGetset(c *server.Peer, cmd string, args []string) {
 		old, ok := db.stringKeys[key]
 		db.stringSet(key, value)
 		// a GETSET clears the ttl
+		delete(db.origTtl, key)
 		delete(db.ttl, key)
 
 		if !ok {

--- a/db.go
+++ b/db.go
@@ -41,6 +41,7 @@ func (db *RedisDB) flush() {
 	db.listKeys = map[string]listKey{}
 	db.setKeys = map[string]setKey{}
 	db.sortedsetKeys = map[string]sortedSet{}
+	db.origTtl = map[string]time.Duration{}
 	db.ttl = map[string]time.Duration{}
 }
 
@@ -114,6 +115,7 @@ func (db *RedisDB) del(k string, delTTL bool) {
 	delete(db.keys, k)
 	db.keyVersion[k]++
 	if delTTL {
+		delete(db.origTtl, k)
 		delete(db.ttl, k)
 	}
 	switch t {
@@ -799,4 +801,9 @@ func (db *RedisDB) checkTTL(key string) {
 	if v, ok := db.ttl[key]; ok && v <= 0 {
 		db.del(key, true)
 	}
+}
+
+// Touch resets a key's TTL to its original unmodified value.
+func (db *RedisDB) touch(k string) {
+	db.ttl[k] = db.origTtl[k]
 }

--- a/direct.go
+++ b/direct.go
@@ -416,6 +416,7 @@ func (db *RedisDB) SetTTL(k string, ttl time.Duration) {
 	defer db.master.Unlock()
 	defer db.master.signal.Broadcast()
 
+	db.origTtl[k] = ttl
 	db.ttl[k] = ttl
 	db.keyVersion[k]++
 }

--- a/miniredis.go
+++ b/miniredis.go
@@ -41,6 +41,7 @@ type RedisDB struct {
 	sortedsetKeys   map[string]sortedSet      // ZADD &c. keys
 	streamKeys      map[string]streamKey      // XADD &c. keys
 	streamGroupKeys map[string]streamGroupKey // XREADGROUP &c. keys
+	origTtl         map[string]time.Duration  // unmodified TTL values
 	ttl             map[string]time.Duration  // effective TTL values
 	keyVersion      map[string]uint           // used to watch values
 }
@@ -105,6 +106,7 @@ func newRedisDB(id int, m *Miniredis) RedisDB {
 		sortedsetKeys:   map[string]sortedSet{},
 		streamKeys:      map[string]streamKey{},
 		streamGroupKeys: map[string]streamGroupKey{},
+		origTtl:         map[string]time.Duration{},
 		ttl:             map[string]time.Duration{},
 		keyVersion:      map[string]uint{},
 	}


### PR DESCRIPTION
This PR implements the [TOUCH](https://redis.io/commands/touch) command.

I only have a superficial understanding of miniredis and redis internals, but it seems that they work fundamentally differently with regard to TTLs.  I think redis maintains a "last access time" for each key, whereas miniredis simply decreases the TTL value when time is advanced.

This presented a challenge for implementing the `TOUCH` command because the original TTL value is not preserved when advancing time.

The solution I propose in this PR is to also keep an unmodified "original" TTL.  Advancing time counts down the TTL just as it did before but the original TTL is not modified.  So now `TOUCH` can reset the TTL to the original value.

`make test` and `make int` both pass locally on redis 5.0.3.

Please feel free to use or modify the contents of this PR as you see fit.
Thanks for a useful library.  I hope my suggestion is helpful.