### PR TITLE
Fix TOUCH implementation to be a NOOP

### DIFF
--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -86,7 +86,6 @@ func makeCmdExpire(m *Miniredis, unix bool, d time.Duration) func(*server.Peer, 
 			} else {
 				db.ttl[key] = time.Duration(i) * d
 			}
-			db.origTtl[key] = db.ttl[key]
 			db.keyVersion[key]++
 			db.checkTTL(key)
 			c.WriteInt(1)
@@ -116,7 +115,6 @@ func (m *Miniredis) cmdTouch(c *server.Peer, cmd string, args []string) {
 		for _, key := range args {
 			if db.exists(key) {
 				count++
-				db.touch(key)
 			}
 		}
 		c.WriteInt(count)
@@ -223,7 +221,6 @@ func (m *Miniredis) cmdPersist(c *server.Peer, cmd string, args []string) {
 			c.WriteInt(0)
 			return
 		}
-		delete(db.origTtl, key)
 		delete(db.ttl, key)
 		db.keyVersion[key]++
 		c.WriteInt(1)

--- a/cmd_string.go
+++ b/cmd_string.go
@@ -121,7 +121,6 @@ func (m *Miniredis) cmdSet(c *server.Peer, cmd string, args []string) {
 		// a vanilla SET clears the expire
 		db.stringSet(key, value)
 		if ttl != 0 {
-			db.origTtl[key] = ttl
 			db.ttl[key] = ttl
 		}
 		c.WriteOK()
@@ -162,7 +161,6 @@ func (m *Miniredis) cmdSetex(c *server.Peer, cmd string, args []string) {
 		db.del(key, true) // Clear any existing keys.
 		db.stringSet(key, value)
 		db.ttl[key] = time.Duration(ttl) * time.Second
-		db.origTtl[key] = db.ttl[key]
 		c.WriteOK()
 	})
 }
@@ -201,7 +199,6 @@ func (m *Miniredis) cmdPsetex(c *server.Peer, cmd string, args []string) {
 		db.del(key, true) // Clear any existing keys.
 		db.stringSet(key, value)
 		db.ttl[key] = time.Duration(ttl) * time.Millisecond
-		db.origTtl[key] = db.ttl[key]
 		c.WriteOK()
 	})
 }
@@ -377,7 +374,6 @@ func (m *Miniredis) cmdGetset(c *server.Peer, cmd string, args []string) {
 		old, ok := db.stringKeys[key]
 		db.stringSet(key, value)
 		// a GETSET clears the ttl
-		delete(db.origTtl, key)
 		delete(db.ttl, key)
 
 		if !ok {

--- a/db.go
+++ b/db.go
@@ -41,7 +41,6 @@ func (db *RedisDB) flush() {
 	db.listKeys = map[string]listKey{}
 	db.setKeys = map[string]setKey{}
 	db.sortedsetKeys = map[string]sortedSet{}
-	db.origTtl = map[string]time.Duration{}
 	db.ttl = map[string]time.Duration{}
 }
 
@@ -103,10 +102,6 @@ func (db *RedisDB) rename(from, to string) {
 	if v, ok := db.ttl[from]; ok {
 		db.ttl[to] = v
 	}
-	if v, ok := db.origTtl[from]; ok {
-		delete(db.origTtl, from)
-		db.origTtl[to] = v
-	}
 
 	db.del(from, true)
 }
@@ -119,7 +114,6 @@ func (db *RedisDB) del(k string, delTTL bool) {
 	delete(db.keys, k)
 	db.keyVersion[k]++
 	if delTTL {
-		delete(db.origTtl, k)
 		delete(db.ttl, k)
 	}
 	switch t {
@@ -808,9 +802,4 @@ func (db *RedisDB) checkTTL(key string) {
 	if v, ok := db.ttl[key]; ok && v <= 0 {
 		db.del(key, true)
 	}
-}
-
-// Touch resets a key's TTL to its original unmodified value.
-func (db *RedisDB) touch(k string) {
-	db.ttl[k] = db.origTtl[k]
 }

--- a/direct.go
+++ b/direct.go
@@ -416,21 +416,8 @@ func (db *RedisDB) SetTTL(k string, ttl time.Duration) {
 	defer db.master.Unlock()
 	defer db.master.signal.Broadcast()
 
-	db.origTtl[k] = ttl
 	db.ttl[k] = ttl
 	db.keyVersion[k]++
-}
-
-// Touch resets the TTL of the key
-func (m *Miniredis) Touch(k string) {
-	m.DB(m.selectedDB).Touch(k)
-}
-
-func (db *RedisDB) Touch(k string) {
-	db.master.Lock()
-	defer db.master.Unlock()
-
-	db.touch(k)
 }
 
 // Type gives the type of a key, or ""

--- a/integration/generic_test.go
+++ b/integration/generic_test.go
@@ -283,17 +283,11 @@ func TestUnlink(t *testing.T) {
 func TestTouch(t *testing.T) {
 	testCommands(t,
 		succ("SET", "a", "some value"),
-		succ("TTL", "a"),
-		succ("EXPIRE", "a", 400),
+		succ("TOUCH", "a"),
+		succ("GET", "a"),
 		succ("TTL", "a"),
 
-		succ("TOUCH", "a"),
-		succ("TTL", "a"),
 		succ("TOUCH", "a", "foobar", "a"),
-
-		succ("RENAME", "a", "a2"),
-		succ("TOUCH", "a"),
-		succ("TTL", "a"), // hard to test
 
 		fail("TOUCH"),
 	)

--- a/miniredis.go
+++ b/miniredis.go
@@ -41,7 +41,6 @@ type RedisDB struct {
 	sortedsetKeys   map[string]sortedSet      // ZADD &c. keys
 	streamKeys      map[string]streamKey      // XADD &c. keys
 	streamGroupKeys map[string]streamGroupKey // XREADGROUP &c. keys
-	origTtl         map[string]time.Duration  // unmodified TTL values
 	ttl             map[string]time.Duration  // effective TTL values
 	keyVersion      map[string]uint           // used to watch values
 }
@@ -106,7 +105,6 @@ func newRedisDB(id int, m *Miniredis) RedisDB {
 		sortedsetKeys:   map[string]sortedSet{},
 		streamKeys:      map[string]streamKey{},
 		streamGroupKeys: map[string]streamGroupKey{},
-		origTtl:         map[string]time.Duration{},
 		ttl:             map[string]time.Duration{},
 		keyVersion:      map[string]uint{},
 	}


### PR DESCRIPTION
All the `origTtl` stuff has been removed.
Tests updated accordingly and I also included a unit test to check that TOUCH does not modify TTL since it's difficult to verify that in integration tests.

Again, really sorry for my misunderstanding of how this command is supposed to work.