### PR TITLE
CLUSTER keyslot and CLUSTER nodes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Implemented commands:
    - COMMAND -- partly
  - Cluster
    - CLUSTER SLOTS
+   - CLUSTER KEYSLOT
+   - CLUSTER NODES
 
 
 ## TTLs, key expiration, and time

--- a/cmd_cluster.go
+++ b/cmd_cluster.go
@@ -16,6 +16,10 @@ func commandsCluster(m *Miniredis) {
 func (m *Miniredis) cmdCluster(c *server.Peer, cmd string, args []string) {
 	if len(args) == 1 && strings.ToUpper(args[0]) == "SLOTS" {
 		m.cmdClusterSlots(c, cmd, args)
+	} else if len(args) == 2 && strings.ToUpper(args[0]) == "KEYSLOT" {
+		m.cmdClusterKeySlot(c, cmd, args)
+	} else if len(args) == 1 && strings.ToUpper(args[0]) == "NODES" {
+		m.cmdClusterNodes(c, cmd, args)
 	} else {
 		j := strings.Join(args, " ")
 		err := fmt.Sprintf("ERR 'CLUSTER %s' not supported", j)
@@ -37,3 +41,18 @@ func (m *Miniredis) cmdClusterSlots(c *server.Peer, cmd string, args []string) {
 		c.WriteBulk("09dbe9720cda62f7865eabc5fd8857c5d2678366")
 	})
 }
+
+//CLUSTER KEYSLOT
+func (m *Miniredis) cmdClusterKeySlot(c *server.Peer, cmd string, args []string) {
+	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
+		c.WriteInt(163)
+	})
+}
+
+//CLUSTER NODES
+func (m *Miniredis) cmdClusterNodes(c *server.Peer, cmd string, args []string) {
+	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
+		c.WriteBulk("e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:7000@7000 myself,master - 0 0 1 connected 0-16383")
+	})
+}
+

--- a/cmd_cluster_test.go
+++ b/cmd_cluster_test.go
@@ -30,3 +30,34 @@ func TestClusterSlots(t *testing.T) {
 		equals(t, s.Addr(), addr)
 	}
 }
+
+// Test CLUSTER NODES.
+func TestClusterNodes(t *testing.T) {
+	s, err := Run()
+	ok(t, err)
+	defer s.Close()
+	c, err := redis.Dial("tcp", s.Addr())
+	ok(t, err)
+
+	{
+		v, err := redis.String(c.Do("CLUSTER", "NODES"))
+		ok(t, err)
+		equals(t, "e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:7000@7000 myself,master - 0 0 1 connected 0-16383", v)
+	}
+}
+
+// Test CLUSTER SLOTS.
+func TestClusterKeyslot(t *testing.T) {
+	s, err := Run()
+	ok(t, err)
+	defer s.Close()
+	c, err := redis.Dial("tcp", s.Addr())
+	ok(t, err)
+
+	{
+		v, err := redis.Int(c.Do("CLUSTER", "keyslot", "{test_key}"))
+		ok(t, err)
+		equals(t, 163, v)
+	}
+}
+

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -7,6 +7,8 @@ import "testing"
 func TestCluster(t *testing.T) {
 	testClusterCommands(t,
 		succNoResultCheck("CLUSTER", "SLOTS"),
+		succNoResultCheck("CLUSTER", "KEYSLOT", "{test}"),
+		succNoResultCheck("CLUSTER", "NODES"),
 		failLoosely("CLUSTER"),
 	)
 }


### PR DESCRIPTION
Hi, 

I need the support of these two commands for testing a project. 

I added them quickly with the unit tests and the integration tests. I launch theses and it was all good. I don't think it's useful to change the keyslot response according to the key passed as an argument. 


`make test` and `make int` worked with redis 5.0.8. 
I also tested the modification in my  project and go-redis fully understand the response
Thanks for a useful library.
