### PR TITLE
update the Check*() methods to use a t.Helper()

### DIFF
--- a/check.go
+++ b/check.go
@@ -1,30 +1,28 @@
 package miniredis
 
-// 'Fail' methods.
-
 import (
-	"fmt"
-	"path/filepath"
 	"reflect"
-	"runtime"
 	"sort"
 )
 
 // T is implemented by Testing.T
 type T interface {
-	Fail()
+	Helper()
+	Errorf(string, ...interface{})
 }
 
 // CheckGet does not call Errorf() iff there is a string key with the
 // expected value. Normal use case is `m.CheckGet(t, "username", "theking")`.
 func (m *Miniredis) CheckGet(t T, key, expected string) {
+	t.Helper()
+
 	found, err := m.Get(key)
 	if err != nil {
-		lError(t, "GET error, key %#v: %v", key, err)
+		t.Errorf("GET error, key %#v: %v", key, err)
 		return
 	}
 	if found != expected {
-		lError(t, "GET error, key %#v: Expected %#v, got %#v", key, expected, found)
+		t.Errorf("GET error, key %#v: Expected %#v, got %#v", key, expected, found)
 		return
 	}
 }
@@ -33,13 +31,15 @@ func (m *Miniredis) CheckGet(t T, key, expected string) {
 // expected values.
 // Normal use case is `m.CheckGet(t, "favorite_colors", "red", "green", "infrared")`.
 func (m *Miniredis) CheckList(t T, key string, expected ...string) {
+	t.Helper()
+
 	found, err := m.List(key)
 	if err != nil {
-		lError(t, "List error, key %#v: %v", key, err)
+		t.Errorf("List error, key %#v: %v", key, err)
 		return
 	}
 	if !reflect.DeepEqual(expected, found) {
-		lError(t, "List error, key %#v: Expected %#v, got %#v", key, expected, found)
+		t.Errorf("List error, key %#v: Expected %#v, got %#v", key, expected, found)
 		return
 	}
 }
@@ -48,21 +48,16 @@ func (m *Miniredis) CheckList(t T, key string, expected ...string) {
 // expected values.
 // Normal use case is `m.CheckSet(t, "visited", "Rome", "Stockholm", "Dublin")`.
 func (m *Miniredis) CheckSet(t T, key string, expected ...string) {
+	t.Helper()
+
 	found, err := m.Members(key)
 	if err != nil {
-		lError(t, "Set error, key %#v: %v", key, err)
+		t.Errorf("Set error, key %#v: %v", key, err)
 		return
 	}
 	sort.Strings(expected)
 	if !reflect.DeepEqual(expected, found) {
-		lError(t, "Set error, key %#v: Expected %#v, got %#v", key, expected, found)
+		t.Errorf("Set error, key %#v: Expected %#v, got %#v", key, expected, found)
 		return
 	}
-}
-
-func lError(t T, format string, args ...interface{}) {
-	_, file, line, _ := runtime.Caller(2)
-	prefix := fmt.Sprintf("%s:%d: ", filepath.Base(file), line)
-	fmt.Printf(prefix+format+"\n", args...)
-	t.Fail()
 }


### PR DESCRIPTION
This file hasn't been touched in 5 years, and used very old 'runtime' functions, which are done with `t.Helper()` nowadays. These `Check...()` commands were an experiment back then, and since no-one every asked to add `Check..()` functions for more redis commands they don't look very useful.

Since we changed the interface `T` this is an non-backwards compatible change, but both versions work with a `*testing.T`.