### PR TITLE
deal with (p)unsubscribe when there are no channels

### DIFF
--- a/cmd_pubsub.go
+++ b/cmd_pubsub.go
@@ -77,6 +77,15 @@ func (m *Miniredis) cmdUnsubscribe(c *server.Peer, cmd string, args []string) {
 				w.WriteInt(n)
 			})
 		}
+		if len(channels) == 0 {
+			// special case: there is always a reply
+			c.Block(func(w *server.Writer) {
+				w.WritePushLen(3)
+				w.WriteBulk("unsubscribe")
+				w.WriteNull()
+				w.WriteInt(0)
+			})
+		}
 
 		if sub.Count() == 0 {
 			endSubscriber(m, c)
@@ -140,6 +149,15 @@ func (m *Miniredis) cmdPunsubscribe(c *server.Peer, cmd string, args []string) {
 				w.WriteBulk("punsubscribe")
 				w.WriteBulk(pat)
 				w.WriteInt(n)
+			})
+		}
+		if len(patterns) == 0 {
+			// special case: there is always a reply
+			c.Block(func(w *server.Writer) {
+				w.WritePushLen(3)
+				w.WriteBulk("punsubscribe")
+				w.WriteNull()
+				w.WriteInt(0)
 			})
 		}
 

--- a/cmd_pubsub_test.go
+++ b/cmd_pubsub_test.go
@@ -166,6 +166,24 @@ func TestUnsubscribe(t *testing.T) {
 	})
 }
 
+func TestUnsubscribeEmpty(t *testing.T) {
+	s, err := Run()
+	ok(t, err)
+	defer s.Close()
+	c, err := proto.Dial(s.Addr())
+	ok(t, err)
+	defer c.Close()
+
+	mustDo(t, c,
+		"UNSUBSCRIBE",
+		proto.Array(
+			proto.String("unsubscribe"),
+			proto.Nil,
+			proto.Int(0),
+		),
+	)
+}
+
 func TestPsubscribe(t *testing.T) {
 	s, err := Run()
 	ok(t, err)
@@ -281,6 +299,24 @@ func TestPunsubscribe(t *testing.T) {
 			),
 		)
 	})
+}
+
+func TestPunsubscribeEmpty(t *testing.T) {
+	s, err := Run()
+	ok(t, err)
+	defer s.Close()
+	c, err := proto.Dial(s.Addr())
+	ok(t, err)
+	defer c.Close()
+
+	mustDo(t, c,
+		"PUNSUBSCRIBE",
+		proto.Array(
+			proto.String("punsubscribe"),
+			proto.Nil,
+			proto.Int(0),
+		),
+	)
 }
 
 func TestPublishMode(t *testing.T) {

--- a/integration/pubsub_test.go
+++ b/integration/pubsub_test.go
@@ -18,10 +18,14 @@ func TestSubscribe(t *testing.T) {
 		c.Do("UNSUBSCRIBE", "foo")
 
 		c.Do("SUBSCRIBE", "foo", "bar")
+		c.Receive()
 		c.Do("UNSUBSCRIBE", "foo", "bar")
+		c.Receive()
 
 		c.Do("SUBSCRIBE", "-1")
 		c.Do("UNSUBSCRIBE", "-1")
+
+		c.Do("UNSUBSCRIBE")
 	})
 }
 
@@ -95,6 +99,11 @@ func TestPsubscribe(t *testing.T) {
 		c1.Do("PSUBSCRIBE", "news") // no pattern
 		c2.Do("PUBLISH", "news", "fire!")
 		c1.Receive()
+	})
+
+	testRaw(t, func(c *client) {
+		c.Do("PUNSUBSCRIBE")
+		c.Do("PUNSUBSCRIBE")
 	})
 }
 


### PR DESCRIPTION
Shouldfix #183

It's not documented here https://redis.io/commands/unsubscribe what needs to be done, and this seems a bit ugly. But it does make sense there should be _some_ kind of reply.