### PR TITLE
fix non-existing XREAD keys, and check the ids given to XREAD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install: go get -t
 script: make test testrace int
 
 go:
-  - "1.14"
   - "1.15"
+  - "1.16"

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -267,7 +267,9 @@ func TestStreamRead(t *testing.T) {
 
 		// failure cases
 		c.Do("XREAD")
+		c.Do("XREAD", "STREAMS")
 		c.Do("XREAD", "STREAMS", "foo")
+		c.Do("XREAD", "STREAMS", "foo", "0")
 		c.Do("XREAD", "STREAMS", "ordplanets")
 		c.Do("XREAD", "STREAMS", "ordplanets", "foo", "0")
 		c.Do("XREAD", "COUNT")


### PR DESCRIPTION
Non existing streams should be handled as empty streams.
Invalid id formats were ignored, but they should raise an error.

Should fix #198