### PR TITLE
support SET EXAT and SET PXAT

### DIFF
--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -72,17 +72,7 @@ func makeCmdExpire(m *Miniredis, unix bool, d time.Duration) func(*server.Peer, 
 				return
 			}
 			if unix {
-				var ts time.Time
-				switch d {
-				case time.Millisecond:
-					ts = time.Unix(int64(i/1000), 1000000*int64(i%1000))
-				case time.Second:
-					ts = time.Unix(int64(i), 0)
-				default:
-					panic("invalid time unit (d). Fixme!")
-				}
-				now := m.effectiveNow()
-				db.ttl[key] = ts.Sub(now)
+				db.ttl[key] = m.at(i, d)
 			} else {
 				db.ttl[key] = time.Duration(i) * d
 			}

--- a/cmd_string_test.go
+++ b/cmd_string_test.go
@@ -177,6 +177,30 @@ func TestSet(t *testing.T) {
 		)
 	})
 
+	t.Run("EXAT", func(t *testing.T) {
+		s.SetTime(time.Unix(1234567890, 0))
+		mustOK(t, c,
+			"SET", "exat", "bar", "EXAT", "2345678901",
+		)
+		equals(t, time.Second*1111111011, s.TTL("exat"))
+		mustDo(t, c,
+			"SET", "exat", "bal", "EXAT", "-1",
+			proto.Error(msgInvalidSETime),
+		)
+	})
+
+	t.Run("PXAT", func(t *testing.T) {
+		s.SetTime(time.Unix(1234567890, 0))
+		mustOK(t, c,
+			"SET", "pxat", "bar", "PXAT", "3345678901000",
+		)
+		equals(t, time.Second*2111111011, s.TTL("pxat"))
+		mustDo(t, c,
+			"SET", "pxat", "bal", "PXAT", "-1",
+			proto.Error(msgInvalidSETime),
+		)
+	})
+
 	t.Run("errors", func(t *testing.T) {
 		mustDo(t, c,
 			"SET", "one", "two", "FOO",

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main
@@ -10,7 +11,7 @@ func TestCluster(t *testing.T) {
 			// c.DoLoosly("CLUSTER", "SLOTS")
 			c.DoLoosely("CLUSTER", "KEYSLOT", "{test}")
 			c.DoLoosely("CLUSTER", "NODES")
-			c.Error("wrong number","CLUSTER")
+			c.Error("wrong number", "CLUSTER")
 		},
 	)
 }

--- a/integration/command_test.go
+++ b/integration/command_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/connection_test.go
+++ b/integration/connection_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/ephemeral.go
+++ b/integration/ephemeral.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/generic_test.go
+++ b/integration/generic_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/geo_test.go
+++ b/integration/geo_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/hash_test.go
+++ b/integration/hash_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main
@@ -26,23 +27,23 @@ func TestHash(t *testing.T) {
 			c.Do("EXISTS", "aap") // key is gone
 
 			// failure cases
-			c.Error("wrong number","HSET", "aap", "noot")
-			c.Error("wrong number","HGET", "aap")
-			c.Error("wrong number","HMGET", "aap")
-			c.Error("wrong number","HLEN")
-			c.Error("wrong number","HKEYS")
-			c.Error("wrong number","HVALS")
+			c.Error("wrong number", "HSET", "aap", "noot")
+			c.Error("wrong number", "HGET", "aap")
+			c.Error("wrong number", "HMGET", "aap")
+			c.Error("wrong number", "HLEN")
+			c.Error("wrong number", "HKEYS")
+			c.Error("wrong number", "HVALS")
 			c.Do("SET", "str", "I am a string")
-			c.Error("wrong kind","HSET", "str", "noot", "mies")
-			c.Error("wrong kind","HGET", "str", "noot")
-			c.Error("wrong kind","HMGET", "str", "noot")
-			c.Error("wrong kind","HLEN", "str")
-			c.Error("wrong kind","HKEYS", "str")
-			c.Error("wrong kind","HVALS", "str")
-			c.Error("wrong number","HSET")
-			c.Error("wrong number","HSET", "a1")
-			c.Error("wrong number","HSET", "a1", "b")
-			c.Error("wrong number","HSET", "a2", "b", "c", "d")
+			c.Error("wrong kind", "HSET", "str", "noot", "mies")
+			c.Error("wrong kind", "HGET", "str", "noot")
+			c.Error("wrong kind", "HMGET", "str", "noot")
+			c.Error("wrong kind", "HLEN", "str")
+			c.Error("wrong kind", "HKEYS", "str")
+			c.Error("wrong kind", "HVALS", "str")
+			c.Error("wrong number", "HSET")
+			c.Error("wrong number", "HSET", "a1")
+			c.Error("wrong number", "HSET", "a1", "b")
+			c.Error("wrong number", "HSET", "a2", "b", "c", "d")
 		})
 	})
 
@@ -69,9 +70,9 @@ func TestHashSetnx(t *testing.T) {
 		c.Do("HGET", "aap", "noot")
 
 		// failure cases
-		c.Error("wrong number","HSETNX", "aap")
-		c.Error("wrong number","HSETNX", "aap", "noot")
-		c.Error("wrong number","HSETNX", "aap", "noot", "too", "many")
+		c.Error("wrong number", "HSETNX", "aap")
+		c.Error("wrong number", "HSETNX", "aap", "noot")
+		c.Error("wrong number", "HSETNX", "aap", "noot", "too", "many")
 	})
 }
 
@@ -88,15 +89,15 @@ func TestHashDelExists(t *testing.T) {
 		c.Do("HEXISTS", "nosuch", "vuur")
 
 		// failure cases
-		c.Error("wrong number","HDEL")
-		c.Error("wrong number","HDEL", "aap")
+		c.Error("wrong number", "HDEL")
+		c.Error("wrong number", "HDEL", "aap")
 		c.Do("SET", "str", "I am a string")
-		c.Error("wrong kind","HDEL", "str", "key")
+		c.Error("wrong kind", "HDEL", "str", "key")
 
-		c.Error("wrong number","HEXISTS")
-		c.Error("wrong number","HEXISTS", "aap")
-		c.Error("wrong number","HEXISTS", "aap", "too", "many")
-		c.Error("wrong kind","HEXISTS", "str", "field")
+		c.Error("wrong number", "HEXISTS")
+		c.Error("wrong number", "HEXISTS", "aap")
+		c.Error("wrong number", "HEXISTS", "aap", "too", "many")
+		c.Error("wrong kind", "HEXISTS", "str", "field")
 	})
 }
 
@@ -109,10 +110,10 @@ func TestHashGetall(t *testing.T) {
 		c.Do("HGETALL", "nosuch")
 
 		// failure cases
-		c.Error("wrong number","HGETALL")
-		c.Error("wrong number","HGETALL", "too", "many")
+		c.Error("wrong number", "HGETALL")
+		c.Error("wrong number", "HGETALL", "too", "many")
 		c.Do("SET", "str", "I am a string")
-		c.Error("wrong kind","HGETALL", "str")
+		c.Error("wrong kind", "HGETALL", "str")
 	})
 
 	testRESP3(t, func(c *client) {
@@ -133,11 +134,11 @@ func TestHmset(t *testing.T) {
 		c.Do("HLEN", "aap")
 
 		// failure cases
-		c.Error("wrong number","HMSET", "aap")
-		c.Error("wrong number","HMSET", "aap", "key")
-		c.Error("wrong number","HMSET", "aap", "key", "value", "odd")
+		c.Error("wrong number", "HMSET", "aap")
+		c.Error("wrong number", "HMSET", "aap", "key")
+		c.Error("wrong number", "HMSET", "aap", "key", "value", "odd")
 		c.Do("SET", "str", "I am a string")
-		c.Error("wrong kind","HMSET", "str", "key", "value")
+		c.Error("wrong kind", "HMSET", "str", "key", "value")
 	})
 }
 
@@ -149,13 +150,13 @@ func TestHashIncr(t *testing.T) {
 		c.Do("HGET", "aap", "noot")
 
 		// Simple failure cases.
-		c.Error("wrong number","HINCRBY")
-		c.Error("wrong number","HINCRBY", "aap")
-		c.Error("wrong number","HINCRBY", "aap", "noot")
-		c.Error("not an integer","HINCRBY", "aap", "noot", "noint")
-		c.Error("wrong number","HINCRBY", "aap", "noot", "12", "toomany")
+		c.Error("wrong number", "HINCRBY")
+		c.Error("wrong number", "HINCRBY", "aap")
+		c.Error("wrong number", "HINCRBY", "aap", "noot")
+		c.Error("not an integer", "HINCRBY", "aap", "noot", "noint")
+		c.Error("wrong number", "HINCRBY", "aap", "noot", "12", "toomany")
 		c.Do("SET", "str", "value")
-		c.Error("wrong kind","HINCRBY", "str", "value", "12")
+		c.Error("wrong kind", "HINCRBY", "str", "value", "12")
 		c.Do("HINCRBY", "aap", "noot", "12")
 	})
 
@@ -166,13 +167,13 @@ func TestHashIncr(t *testing.T) {
 		c.Do("HGET", "aap", "noot")
 
 		// Simple failure cases.
-		c.Error("wrong number","HINCRBYFLOAT")
-		c.Error("wrong number","HINCRBYFLOAT", "aap")
-		c.Error("wrong number","HINCRBYFLOAT", "aap", "noot")
-		c.Error("not a valid float","HINCRBYFLOAT", "aap", "noot", "noint")
-		c.Error("wrong number","HINCRBYFLOAT", "aap", "noot", "12", "toomany")
+		c.Error("wrong number", "HINCRBYFLOAT")
+		c.Error("wrong number", "HINCRBYFLOAT", "aap")
+		c.Error("wrong number", "HINCRBYFLOAT", "aap", "noot")
+		c.Error("not a valid float", "HINCRBYFLOAT", "aap", "noot", "noint")
+		c.Error("wrong number", "HINCRBYFLOAT", "aap", "noot", "12", "toomany")
 		c.Do("SET", "str", "value")
-		c.Error("wrong kind","HINCRBYFLOAT", "str", "value", "12")
+		c.Error("wrong kind", "HINCRBYFLOAT", "str", "value", "12")
 		c.Do("HINCRBYFLOAT", "aap", "noot", "12")
 	})
 }
@@ -197,16 +198,16 @@ func TestHscan(t *testing.T) {
 		// c.Do("SCAN", "0")
 
 		// Error cases
-		c.Error("wrong number","HSCAN")
-		c.Error("wrong number","HSCAN", "noint")
-		c.Error("not an integer","HSCAN", "h", "0", "COUNT", "noint")
-		c.Error("syntax error","HSCAN", "h", "0", "COUNT")
-		c.Error("syntax error","HSCAN", "h", "0", "MATCH")
-		c.Error("syntax error","HSCAN", "h", "0", "garbage")
-		c.Error("syntax error","HSCAN", "h", "0", "COUNT", "12", "MATCH", "foo", "garbage")
+		c.Error("wrong number", "HSCAN")
+		c.Error("wrong number", "HSCAN", "noint")
+		c.Error("not an integer", "HSCAN", "h", "0", "COUNT", "noint")
+		c.Error("syntax error", "HSCAN", "h", "0", "COUNT")
+		c.Error("syntax error", "HSCAN", "h", "0", "MATCH")
+		c.Error("syntax error", "HSCAN", "h", "0", "garbage")
+		c.Error("syntax error", "HSCAN", "h", "0", "COUNT", "12", "MATCH", "foo", "garbage")
 		// c.Do("HSCAN", "nosuch", "0", "COUNT", "garbage")
 		c.Do("SET", "str", "1")
-		c.Error("wrong kind","HSCAN", "str", "0")
+		c.Error("wrong kind", "HSCAN", "str", "0")
 	})
 }
 
@@ -218,10 +219,10 @@ func TestHstrlen(t *testing.T) {
 		c.Do("HSTRLEN", "hash", "nosuch")
 		c.Do("HSTRLEN", "nosuch", "nosuch")
 
-		c.Error("wrong number","HSTRLEN")
-		c.Error("wrong number","HSTRLEN", "foo")
-		c.Error("wrong number","HSTRLEN", "foo", "baz", "bar")
+		c.Error("wrong number", "HSTRLEN")
+		c.Error("wrong number", "HSTRLEN", "foo")
+		c.Error("wrong number", "HSTRLEN", "foo", "baz", "bar")
 		c.Do("SET", "str", "1")
-		c.Error("wrong kind","HSTRLEN", "str", "bar")
+		c.Error("wrong kind", "HSTRLEN", "str", "bar")
 	})
 }

--- a/integration/hll_test.go
+++ b/integration/hll_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/list_test.go
+++ b/integration/list_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/pubsub_test.go
+++ b/integration/pubsub_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/script_test.go
+++ b/integration/script_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main
@@ -29,12 +30,12 @@ func TestServer(t *testing.T) {
 		c.Do("FLUSHALL", "AsYnC")
 
 		// Failure cases
-		c.Error("wrong number","DBSIZE", "foo")
-		c.Error("syntax error","FLUSHDB", "foo")
-		c.Error("syntax error","FLUSHALL", "foo")
-		c.Error("syntax error","FLUSHDB", "ASYNC", "foo")
-		c.Error("syntax error","FLUSHDB", "ASYNC", "ASYNC")
-		c.Error("syntax error","FLUSHALL", "ASYNC", "foo")
+		c.Error("wrong number", "DBSIZE", "foo")
+		c.Error("syntax error", "FLUSHDB", "foo")
+		c.Error("syntax error", "FLUSHALL", "foo")
+		c.Error("syntax error", "FLUSHDB", "ASYNC", "foo")
+		c.Error("syntax error", "FLUSHDB", "ASYNC", "ASYNC")
+		c.Error("syntax error", "FLUSHALL", "ASYNC", "foo")
 	})
 }
 

--- a/integration/set_test.go
+++ b/integration/set_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/sorted_set_test.go
+++ b/integration/sorted_set_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/string_test.go
+++ b/integration/string_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/string_test.go
+++ b/integration/string_test.go
@@ -23,6 +23,16 @@ func TestString(t *testing.T) {
 		c.Do("SET", "empty", "filled", "GET")
 		c.Do("SET", "empty", "", "GET")
 
+		c.Do("SET", "fooexat", "bar", "EXAT", "2345678901")
+		c.DoApprox(10, "TTL", "fooexat")
+		c.Error("not an integer", "SET", "foo", "bar", "EXAT", "noint")
+		c.Do("SET", "foopxat", "bar", "PXAT", "2345678901000")
+		c.DoApprox(10, "TTL", "foopxat")
+		c.Error("not an integer", "SET", "foo", "bar", "PXAT", "noint")
+		// expires right away
+		c.Do("SET", "gone", "bar", "EXAT", "123")
+		c.Do("EXISTS", "gone")
+
 		// Failure cases
 		c.Error("wrong number", "SET")
 		c.Error("wrong number", "SET", "foo")
@@ -31,6 +41,12 @@ func TestString(t *testing.T) {
 		c.Error("wrong number", "GET", "too", "many")
 		c.Error("invalid expire", "SET", "foo", "bar", "EX", "0")
 		c.Error("invalid expire", "SET", "foo", "bar", "EX", "-100")
+		c.Error("syntax error", "SET", "both", "bar", "PXAT", "3345678901000", "EXAT", "2345678901")
+		c.Error("invalid expire", "SET", "foo", "bar", "EXAT", "-100")
+		c.Error("invalid expire", "SET", "foo", "bar", "PXAT", "-100")
+		c.Error("syntax error", "SET", "both", "bar", "PX", "6", "EX", "6")
+		c.Error("syntax error", "SET", "both", "bar", "PX", "6", "EX", "0")
+		c.Error("syntax error", "SET", "both", "bar", "PX", "6", "PXAT", "2345678901")
 		// Wrong type
 		c.Do("HSET", "hash", "key", "value")
 		c.Error("wrong kind", "GET", "hash")

--- a/integration/test.go
+++ b/integration/test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/test.go
+++ b/integration/test.go
@@ -482,7 +482,7 @@ func (c *client) DoRounded(rounded int, cmd string, args ...string) {
 	}
 }
 
-// result must match, with floats rounded
+// result must be a single int, with value within threshold
 func (c *client) DoApprox(threshold int, cmd string, args ...string) {
 	c.t.Helper()
 

--- a/integration/tls.go
+++ b/integration/tls.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/integration/tx_test.go
+++ b/integration/tx_test.go
@@ -1,3 +1,4 @@
+//go:build int
 // +build int
 
 package main

--- a/miniredis.go
+++ b/miniredis.go
@@ -604,3 +604,19 @@ func (m *Miniredis) effectiveNow() time.Time {
 	}
 	return time.Now().UTC()
 }
+
+// convert a unixtimestamp to a duration, to use an absolute time as TTL.
+// d can be either time.Second or time.Millisecond.
+func (m *Miniredis) at(i int, d time.Duration) time.Duration {
+	var ts time.Time
+	switch d {
+	case time.Millisecond:
+		ts = time.Unix(int64(i/1000), 1000000*int64(i%1000))
+	case time.Second:
+		ts = time.Unix(int64(i), 0)
+	default:
+		panic("invalid time unit (d). Fixme!")
+	}
+	now := m.effectiveNow()
+	return ts.Sub(now)
+}


### PR DESCRIPTION
Fixes #192. The `EXAT` and `PXAT` options behave the same as `EXPIRE` and `PEXPIRE`: if you don't do anything the times set will be compared to `time.Now()`. If you ever set `m.SetTime(t)` that time is the comparison time.