### PR TITLE
redis.call() should return a "status_reply" for simple strings

### DIFF
--- a/integration/script_test.go
+++ b/integration/script_test.go
@@ -243,6 +243,15 @@ func TestLuaCall(t *testing.T) {
 		c.Do("EVAL", `return redis.call("GET", "foo")`, "0")
 		c.Do("EVAL", `return redis.call("SET", "foo", 42)`, "0")
 		c.Do("EVAL", `redis.log(redis.LOG_NOTICE, "hello")`, "0")
+		c.Do("EVAL", `local res = redis.call("GET", "foo"); return res['ok']`, "0")
+	})
+
+	testRaw(t, func(c *client) {
+		script := `
+			local result = redis.call('SET', 'mykey', 'myvalue', 'NX');
+			return result['ok'];
+		`
+		c.Do("EVAL", script, "0")
 	})
 
 	// datatype errors

--- a/server/proto.go
+++ b/server/proto.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 )
 
+type Simple string
+
 // ErrProtocol is the general error for unexpected input
 var ErrProtocol = errors.New("invalid request")
 
@@ -98,7 +100,7 @@ func ParseReply(rd *bufio.Reader) (interface{}, error) {
 		return nil, ErrProtocol
 	case '+':
 		// +: simple string
-		return string(line[1 : len(line)-2]), nil
+		return Simple(line[1 : len(line)-2]), nil
 	case '-':
 		// -: errors
 		return nil, errors.New(string(line[1 : len(line)-2]))

--- a/server/proto_test.go
+++ b/server/proto_test.go
@@ -131,7 +131,7 @@ func TestParseReply(t *testing.T) {
 	for i, c := range []cas{
 		{
 			payload: "+hello world\r\n",
-			res:     "hello world",
+			res:     Simple("hello world"),
 		},
 		{
 			payload: "-some error\r\n",


### PR DESCRIPTION
For #255 

The docs https://redis.io/topics/lua-api#data-type-conversion say:
> [RESP2 status reply](https://redis.io/topics/protocol#resp-simple-strings) -> Lua table with a single ok field containing the status string

where "status reply" links to "simple strings" (makes sense, there is no such thing as "status reply" in redis).