### PR TITLE
Fix backward compatibility with Go <1.17

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -217,7 +217,7 @@ func redisRange(l, start, end int, stringSymantics bool) (int, int) {
 			}
 		}
 	}
-	if end < math.MinInt32 {
+	if end < math.MaxInt32 {
 		end++ // end argument is inclusive in Redis.
 	}
 	if end > l {

--- a/redis.go
+++ b/redis.go
@@ -217,7 +217,7 @@ func redisRange(l, start, end int, stringSymantics bool) (int, int) {
 			}
 		}
 	}
-	if end < math.MaxInt {
+	if end < math.MinInt32 {
 		end++ // end argument is inclusive in Redis.
 	}
 	if end > l {


### PR DESCRIPTION
MaxInt was added only in 1.17, which broke compatibility with older Go versions. 
Should use `MinInt32` instead.