### PR TITLE
Added support for GT and LT options in ZADD command

### DIFF
--- a/cmd_sorted_set_test.go
+++ b/cmd_sorted_set_test.go
@@ -182,6 +182,14 @@ func TestSortedSetAdd(t *testing.T) {
 			"ZADD", "z", "NX", "1", "one", "2.2", "two", "3", "three",
 		)
 
+		must0(t, c,
+			"ZADD", "z", "GT", "1", "one",
+		)
+
+		must0(t, c,
+			"ZADD", "z", "GT", "2", "one",
+		)
+
 		must1(t, c,
 			"ZADD", "z", "NX", "1", "one", "4", "four",
 		)
@@ -270,6 +278,10 @@ func TestSortedSetAdd(t *testing.T) {
 		mustDo(t, c,
 			"ZADD", "set", "INCR", "1.0", "foo", "2.3", "bar",
 			proto.Error("ERR INCR option supports a single increment-element pair"),
+		)
+		mustDo(t, c,
+			"ZADD", "set", "GT", "LT", "1.0", "foo",
+			proto.Error(msgGTLTandNX),
 		)
 	})
 

--- a/integration/sorted_set_test.go
+++ b/integration/sorted_set_test.go
@@ -153,6 +153,14 @@ func TestSortedSetAdd(t *testing.T) {
 		c.Error("syntax error", "ZADD", "z", "INCR", "-12", "aap", "NX")
 	})
 
+	testRaw(t, func(c *client) {
+		c.Do("ZADD", "z", "1", "score")
+		c.Do("ZADD", "z", "GT", "2", "score")
+		c.Do("ZADD", "z", "LT", "1", "score")
+
+		c.Error("ERR GT, LT, and/or NX options at the same time are not compatible", "ZADD", "z", "GT", "LT", "1", "score")
+	})
+
 	testRESP3(t, func(c *client) {
 		c.Do("ZADD", "z", "INCR", "1", "aap")
 	})

--- a/redis.go
+++ b/redis.go
@@ -35,6 +35,7 @@ const (
 	msgFPubsubUsage         = "ERR Unknown subcommand or wrong number of arguments for '%s'. Try PUBSUB HELP."
 	msgScriptFlush          = "ERR SCRIPT FLUSH only support SYNC|ASYNC option"
 	msgSingleElementPair    = "ERR INCR option supports a single increment-element pair"
+	msgGTLTandNX            = "ERR GT, LT and NX options are mutually exclusive"
 	msgInvalidStreamID      = "ERR Invalid stream ID specified as stream command argument"
 	msgStreamIDTooSmall     = "ERR The ID specified in XADD is equal or smaller than the target stream top item"
 	msgStreamIDZero         = "ERR The ID specified in XADD must be greater than 0-0"

--- a/redis.go
+++ b/redis.go
@@ -35,7 +35,7 @@ const (
 	msgFPubsubUsage         = "ERR Unknown subcommand or wrong number of arguments for '%s'. Try PUBSUB HELP."
 	msgScriptFlush          = "ERR SCRIPT FLUSH only support SYNC|ASYNC option"
 	msgSingleElementPair    = "ERR INCR option supports a single increment-element pair"
-	msgGTLTandNX            = "ERR GT, LT and NX options are mutually exclusive"
+	msgGTLTandNX            = "ERR GT, LT, and/or NX options at the same time are not compatible"
 	msgInvalidStreamID      = "ERR Invalid stream ID specified as stream command argument"
 	msgStreamIDTooSmall     = "ERR The ID specified in XADD is equal or smaller than the target stream top item"
 	msgStreamIDZero         = "ERR The ID specified in XADD must be greater than 0-0"


### PR DESCRIPTION
This PR adds the support for the options GT  and LT in the [ZADD](https://redis.io/commands/zadd/) command.

Not sure how to test correctly so I am welcoming the feedback ;) 