### PR TITLE
Extend `XPENDING` and add support for `XGROUP {CREATECONSUMER,DESTROY,DELCONSUMER}`, `XINFO {CONSUMERS,GROUPS}`, `XCLAIM`

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,15 @@ Implemented commands:
    - XACK
    - XADD
    - XAUTOCLAIM
+   - XCLAIM
    - XDEL
    - XGROUP CREATE
+   - XGROUP CREATECONSUMER
+   - XGROUP DESTROY
+   - XGROUP DELCONSUMER
    - XINFO STREAM -- partly
+   - XINFO GROUPS
+   - XINFO CONSUMERS -- partly
    - XLEN
    - XRANGE
    - XREAD


### PR DESCRIPTION
As stated in the title, this PR adds support for the following commands:
- `XGROUP {CREATECONSUMER,DESTROY,DELCONSUMER}`
-  `XINFO {CONSUMERS,GROUPS}`
-  `XCLAIM`

In addition, I've added support for `IDLE` to the `XPENDING` implementation.