### PR TITLE
Resolve $ to latest ID in XREAD

### DIFF
--- a/cmd_stream.go
+++ b/cmd_stream.go
@@ -924,11 +924,14 @@ parsing:
 			}
 
 			opts.streams, opts.ids = args[0:len(args)/2], args[len(args)/2:]
-			for _, id := range opts.ids {
+			for i, id := range opts.ids {
 				if _, err := parseStreamID(id); id != `$` && err != nil {
 					setDirty(c)
 					c.WriteError(msgInvalidStreamID)
 					return
+				} else if id == "$" {
+					db := m.DB(getCtx(c).selectedDB)
+					opts.ids[i] = db.streamKeys[opts.streams[i]].lastID()
 				}
 			}
 			args = nil

--- a/cmd_stream_test.go
+++ b/cmd_stream_test.go
@@ -417,6 +417,29 @@ func TestStreamRead(t *testing.T) {
 				),
 			),
 		)
+
+		// XREAD blocking test using latest ID
+		go t.Run("XREAD_blocking_async", func(t *testing.T) {
+			mustDo(t, c,
+				"XREAD", "BLOCK", "0", "STREAMS", "planets", "$",
+				proto.Array(
+					proto.Array(proto.String("planets"),
+						proto.Array(
+							proto.Array(proto.String("5-1"), proto.Strings("name", "block", "idx", "6")),
+						),
+					),
+				),
+			)
+		})
+
+		// Wait for the blocking XREAD to start and then run XADD
+		xaddClient, err := proto.Dial(s.Addr())
+		ok(t, err)
+		defer xaddClient.Close()
+
+		time.Sleep(time.Second)
+		_, err = xaddClient.Do("XADD", "planets", "5-1", "name", "block", "idx", "6")
+		ok(t, err)
 	})
 
 	t.Run("error cases", func(t *testing.T) {


### PR DESCRIPTION
Issue https://github.com/alicebob/miniredis/issues/292

If an XREAD STREAM ID is `$` then we should first resolve it to the latest ID, otherwise during a BLOCK we end up polling forever.