### PR TITLE
resolved race condition in blocking stream calls

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -137,14 +137,15 @@ func blocking(
 	m.Lock()
 	defer m.Unlock()
 	for {
+		if m.Ctx.Err() != nil {
+			return
+		}
+
 		done := cb(c, ctx)
 		if done {
 			return
 		}
 
-		if m.Ctx.Err() != nil {
-			return
-		}
 		if timedOut {
 			onTimeout(c)
 			return

--- a/redis_test.go
+++ b/redis_test.go
@@ -1,0 +1,38 @@
+package miniredis
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2/server"
+)
+
+func TestRedis(t *testing.T) {
+	s, err := Run()
+	ok(t, err)
+	defer s.Close()
+
+	peer := &server.Peer{}
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		blocking(s, peer, time.Second, func(p *server.Peer, cc *connCtx) bool {
+			err := s.Ctx.Err()
+			if err != nil {
+				t.Error("blocking call should not retry command when context has error")
+				return true
+			}
+			return false
+		}, func(p *server.Peer) {
+			// expect to time out
+		})
+	}()
+
+	time.Sleep(time.Millisecond * 250)
+
+	s.Close()
+	wg.Wait()
+}


### PR DESCRIPTION
if context is cancelled in the middle of a blocking call, it does one more retry with unintended consequences

Scenario:

two goroutines XADD and XREADGROUP concurrently through go-redis client
context for the latter is cancelled
first goroutine adds one more to the stream
Expected: item added on step 3 is not received by XREADGROUP and is available to other consumers
Actual: item is not returned by XREADGROUP, but is added to pending and linked to the initial consumer