### PR TITLE
support SET NX GET special case

### DIFF
--- a/integration/string_test.go
+++ b/integration/string_test.go
@@ -32,6 +32,13 @@ func TestString(t *testing.T) {
 		c.Do("SET", "gone", "bar", "EXAT", "123")
 		c.Do("EXISTS", "gone")
 
+		// SET NX GET
+		c.Do("SET", "unique", "value1", "NX", "GET")
+		c.Do("SET", "unique", "value2", "NX", "GET")
+		c.Do("SET", "unique", "value3", "XX", "GET")
+		c.Do("SET", "unique", "value4", "XX", "GET")
+		c.Do("SET", "uniquer", "value5", "XX", "GET")
+
 		// Failure cases
 		c.Error("wrong number", "SET")
 		c.Error("wrong number", "SET", "foo")


### PR DESCRIPTION
That should fix #315.

> Starting with Redis version 7.0.0: Allowed the NX and GET options to be used together.

(I see how the case applies to 'SET NX GET', but I don't understand see how it changes the reply for 'SET XX GET', since that will also be nil in the "fail" case. Doesn't matter much.)