### PR TITLE
Support MINID in XADD

### DIFF
--- a/cmd_stream.go
+++ b/cmd_stream.go
@@ -50,6 +50,7 @@ func (m *Miniredis) cmdXadd(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 
 		maxlen := -1
+		minID := ""
 		if strings.ToLower(args[0]) == "maxlen" {
 			args = args[1:]
 			// we don't treat "~" special
@@ -66,6 +67,14 @@ func (m *Miniredis) cmdXadd(c *server.Peer, cmd string, args []string) {
 				return
 			}
 			maxlen = n
+			args = args[1:]
+		} else if strings.ToLower(args[0]) == "minid" {
+			args = args[1:]
+			// we don't treat "~" special
+			if args[0] == "~" {
+				args = args[1:]
+			}
+			minID = args[0]
 			args = args[1:]
 		}
 		if len(args) < 1 {
@@ -109,6 +118,9 @@ func (m *Miniredis) cmdXadd(c *server.Peer, cmd string, args []string) {
 		}
 		if maxlen >= 0 {
 			s.trim(maxlen)
+		}
+		if minID != "" {
+			s.trimBefore(minID)
 		}
 		db.keyVersion[key]++
 
@@ -1329,16 +1341,8 @@ func (m *Miniredis) cmdXtrim(c *server.Peer, cmd string, args []string) {
 			s.trim(opts.maxLen)
 			c.WriteInt(entriesBefore - len(s.entries))
 		case "MINID":
-			var delete []string
-			for _, entry := range s.entries {
-				if entry.ID < opts.threshold {
-					delete = append(delete, entry.ID)
-				} else {
-					break
-				}
-			}
-			s.delete(delete)
-			c.WriteInt(len(delete))
+			n := s.trimBefore(opts.threshold)
+			c.WriteInt(n)
 		}
 	})
 }

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -84,6 +84,28 @@ func TestStream(t *testing.T) {
 			c.Do("SET", "str", "I am a string")
 			c.Error("not an integer", "XADD", "str", "MAXLEN", "four", "*", "foo", "bar")
 		})
+
+		testRaw(t, func(c *client) {
+			c.Do("XADD", "planets", "MINID", "450", "450-0", "name", "Venus")
+			c.Do("XADD", "planets", "MINID", "450", "450-1", "name", "Venus")
+			c.Do("XADD", "planets", "MINID", "450", "456-1", "name", "Mercury")
+			c.Do("XADD", "planets", "MINID", "450", "456-2", "name", "Mercury")
+			c.Do("XADD", "planets", "MINID", "450", "456-3", "name", "Mercury")
+			c.Do("XADD", "planets", "MINID", "450", "456-4", "name", "Mercury")
+			c.Do("XADD", "planets", "MINID", "450", "456-5", "name", "Mercury")
+			c.Do("XADD", "planets", "MINID", "450", "456-6", "name", "Mercury")
+			c.Do("XADD", "planets", "MINID", "~", "450", "456-7", "name", "Mercury")
+			c.Do("XLEN", "planets")
+
+			c.Error("equal or smaller than the target", "XADD", "planets", "MINID", "450", "449-0", "name", "Earth")
+			c.Error("equal or smaller than the target", "XADD", "planets", "MINID", "450", "450", "name", "Earth")
+			c.Error("wrong number", "XADD", "planets", "MINID", "~")
+			c.Error("wrong number", "XADD", "planets", "MINID")
+			c.Error("wrong number", "XADD", "planets", "MINID", "100")
+
+			c.Do("SET", "str", "I am a string")
+			c.Error("key holding the wrong kind of value", "XADD", "str", "MINID", "400", "*", "foo", "bar")
+		})
 	})
 
 	t.Run("transactions", func(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -265,6 +265,23 @@ func (s *streamKey) trim(n int) {
 	}
 }
 
+// trimBefore deletes entries with an id less than the provided id
+// and returns the number of entries deleted
+func (s *streamKey) trimBefore(id string) int {
+	s.mu.Lock()
+	var delete []string
+	for _, entry := range s.entries {
+		if entry.ID < id {
+			delete = append(delete, entry.ID)
+		} else {
+			break
+		}
+	}
+	s.mu.Unlock()
+	s.delete(delete)
+	return len(delete)
+}
+
 // all entries after "id"
 func (s *streamKey) after(id string) []StreamEntry {
 	s.mu.Lock()


### PR DESCRIPTION
According to https://redis.io/commands/xadd
XADD should support MINID (in addition to MAXLEN) as another means of trimming old entries from the stream.

First added in Redis 6.2.0 https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES