### PR TITLE
fix: handle messages with custom error code in error_reply

### DIFF
--- a/integration/script_test.go
+++ b/integration/script_test.go
@@ -152,6 +152,13 @@ func TestLua(t *testing.T) {
 		c.Error("type of arguments", "EVAL", "return redis.status_reply(1)", "0")
 		c.Error("type of arguments", "EVAL", "return redis.status_reply()", "0")
 		c.Error("type of arguments", "EVAL", "return redis.status_reply(redis.status_reply('foo'))", "0")
+		
+		c.ErrorTheSame("ERR ", "EVAL", "return redis.error_reply('')", "0")
+		c.ErrorTheSame("ERR ", "EVAL", "return redis.error_reply('-')", "0")
+		c.ErrorTheSame("ERR foo", "EVAL", "return redis.error_reply('foo')", "0")
+		c.ErrorTheSame("ERR foo", "EVAL", "return redis.error_reply('-foo')", "0")
+		c.ErrorTheSame("foo bar", "EVAL", "return redis.error_reply('foo bar')", "0")
+		c.ErrorTheSame("foo bar", "EVAL", "return redis.error_reply('-foo bar')", "0")
 	})
 
 	// state inside lua

--- a/lua.go
+++ b/lua.go
@@ -113,7 +113,18 @@ func mkLua(srv *server.Server, c *server.Peer, sha string) (map[string]lua.LGFun
 				return 0
 			}
 			res := &lua.LTable{}
-			res.RawSetString("err", lua.LString("ERR "+msg))
+			parts := strings.SplitN(msg.String(), " ", 2)
+			// '-' at the beginging will be added as a part of error response
+			if parts[0] != "" && parts[0][0] == '-' {
+				parts[0] = parts[0][1:]
+			}
+			var final_msg string
+			if len(parts) == 2 {
+				final_msg = fmt.Sprintf("%s %s", parts[0], parts[1])
+			} else {
+				final_msg = fmt.Sprintf("ERR %s", parts[0])
+			}
+			res.RawSetString("err", lua.LString(final_msg))
 			l.Push(res)
 			return 1
 		},


### PR DESCRIPTION
Redis treats first "word" of error message as custom error code, So `redis.error_reply("foo bar")` returns "-foo bar" but not "-ERR foo bar".
This is a problem for testing application which relies on exact error message returned by Lua script.