### PR TITLE
Added ZMScore command

### DIFF
--- a/db.go
+++ b/db.go
@@ -468,6 +468,16 @@ func (db *RedisDB) ssetScore(key, member string) float64 {
 	return ss[member]
 }
 
+// ssetMScore returns multiple scores of a list of members in a sorted set.
+func (db *RedisDB) ssetMScore(key string, members []string) []float64 {
+	scores := make([]float64, 0, len(members))
+	ss := db.sortedsetKeys[key]
+	for _, member := range members {
+		scores = append(scores, ss[member])
+	}
+	return scores
+}
+
 // ssetRem is sorted set key delete.
 func (db *RedisDB) ssetRem(key, member string) bool {
 	ss := db.sortedsetKeys[key]

--- a/direct.go
+++ b/direct.go
@@ -666,6 +666,24 @@ func (db *RedisDB) ZScore(k, member string) (float64, error) {
 	return db.ssetScore(k, member), nil
 }
 
+// ZScore gives scores of a list of members in a sorted set.
+func (m *Miniredis) ZMScore(k string, members ...string) ([]float64, error) {
+	return m.DB(m.selectedDB).ZMScore(k, members)
+}
+
+func (db *RedisDB) ZMScore(k string, members []string) ([]float64, error) {
+	db.master.Lock()
+	defer db.master.Unlock()
+
+	if !db.exists(k) {
+		return nil, ErrKeyNotFound
+	}
+	if db.t(k) != "zset" {
+		return nil, ErrWrongType
+	}
+	return db.ssetMScore(k, members), nil
+}
+
 // XAdd adds an entry to a stream. `id` can be left empty or be '*'.
 // If a value is given normal XADD rules apply. Values should be an even
 // length.

--- a/integration/sorted_set_test.go
+++ b/integration/sorted_set_test.go
@@ -891,3 +891,24 @@ func TestZrandmember(t *testing.T) {
 		c.Error("not an integer", "ZRANDMEMBER", "q", "two")
 	})
 }
+
+func TestZMScore(t *testing.T) {
+	testRaw(t, func(c *client) {
+		c.Do("ZADD", "q", "1.0", "key1")
+		c.Do("ZADD", "q", "2.0", "key2")
+		c.Do("ZADD", "q", "3.0", "key3")
+		c.Do("ZADD", "q", "4.0", "key4")
+		c.Do("ZADD", "q", "5.0", "key5")
+
+		c.Do("ZMSCORE", "q", "key1")
+		c.Do("ZMSCORE", "q", "key1 key2 key3")
+		c.Do("ZMSCORE", "q", "nosuch")
+		c.Do("ZMSCORE", "nosuch", "key1")
+		c.Do("ZMSCORE", "nosuch", "key1", "key2")
+
+		// failure cases
+		c.Error("wrong number", "ZMSCORE", "q")
+		c.Do("SET", "str", "I am a string")
+		c.Error("wrong kind", "ZMSCORE", "str", "key1")
+	})
+}


### PR DESCRIPTION
This PR adds support for the[ ZMScore command](https://redis.io/commands/zmscore/) in a sorted set.

Let me know what you think and I will updated the PR if needed.

