### PR TITLE
fix; check key existence when applying LT GT option to ZADD

### DIFF
--- a/cmd_sorted_set.go
+++ b/cmd_sorted_set.go
@@ -163,17 +163,18 @@ outer:
 
 		res := 0
 		for member, score := range elems {
-			if opts.nx && db.ssetExists(opts.key, member) {
+			exists := db.ssetExists(opts.key, member)
+			if opts.nx && exists {
 				continue
 			}
-			if opts.xx && !db.ssetExists(opts.key, member) {
+			if opts.xx && !exists {
 				continue
 			}
 			old := db.ssetScore(opts.key, member)
-			if opts.gt && score <= old {
+			if opts.gt && exists && score <= old {
 				continue
 			}
-			if opts.lt && score >= old {
+			if opts.lt && exists && score >= old {
 				continue
 			}
 			if db.ssetAdd(opts.key, score, member) {

--- a/cmd_sorted_set_test.go
+++ b/cmd_sorted_set_test.go
@@ -236,6 +236,13 @@ func TestSortedSetAdd(t *testing.T) {
 		)
 	}
 
+	t.Run("LT and GT options", func(t *testing.T) {
+		must1(t, c, "ZADD", "zlt", "LT", "1", "one")
+		must0(t, c, "ZADD", "zlt", "LT", "2", "one")
+		must1(t, c, "ZADD", "zgt", "GT", "-1", "one")
+		must0(t, c, "ZADD", "zgt", "GT", "-2", "one")
+	})
+
 	t.Run("errors", func(t *testing.T) {
 		// Wrong type of key
 		mustOK(t, c, "SET", "str", "value")


### PR DESCRIPTION
This pr fixes bug which is related to ZADD LT and GT options. 

bug detail:

When I tried to ZADD LT with score bigger than 0, it wasn't applied. It happened same to GT option just in opposite case.(score less than 0)

This bug is from the [implementation of LT and GT options](https://github.com/alicebob/miniredis/pull/267), it didn't check the existence of key so miniredis compared the score with default value(=0). Therefore, I added the logic which checks the existence of the key and if not, then adds the value.

Thanks to @rolancia, he helped me a lot to debug this issue.