### PR TITLE
feat: add client get/set name commands

### DIFF
--- a/cmd_client.go
+++ b/cmd_client.go
@@ -1,0 +1,59 @@
+package miniredis
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alicebob/miniredis/v2/server"
+)
+
+// commandsClient handles client operations.
+func commandsClient(m *Miniredis) {
+	m.srv.Register("CLIENT", m.cmdClient)
+}
+
+// CLIENT
+func (m *Miniredis) cmdClient(c *server.Peer, cmd string, args []string) {
+	if len(args) == 0 {
+		setDirty(c)
+		c.WriteError("ERR wrong number of arguments for 'client' command")
+		return
+	}
+
+	switch strings.ToUpper(args[0]) {
+	case "SETNAME":
+		m.cmdClientSetName(c, args[1:])
+	case "GETNAME":
+		m.cmdClientGetName(c, args[1:])
+	default:
+		setDirty(c)
+		c.WriteError(fmt.Sprintf("ERR 'CLIENT %s' not supported", strings.Join(args, " ")))
+	}
+}
+
+// CLIENT SETNAME
+func (m *Miniredis) cmdClientSetName(c *server.Peer, args []string) {
+	if len(args) != 1 {
+		setDirty(c)
+		c.WriteError("ERR wrong number of arguments for 'client setname' command")
+		return
+	}
+
+	c.ClientName = args[0]
+	c.WriteOK()
+}
+
+// CLIENT GETNAME
+func (m *Miniredis) cmdClientGetName(c *server.Peer, args []string) {
+	if len(args) > 0 {
+		setDirty(c)
+		c.WriteError("ERR wrong number of arguments for 'client getname' command")
+		return
+	}
+
+	if c.ClientName == "" {
+		c.WriteNull()
+	} else {
+		c.WriteBulk(c.ClientName)
+	}
+}

--- a/cmd_client_test.go
+++ b/cmd_client_test.go
@@ -1,0 +1,42 @@
+package miniredis
+
+import (
+	"testing"
+
+	"github.com/alicebob/miniredis/v2/proto"
+)
+
+// Test CLIENT *.
+func TestClient(t *testing.T) {
+	t.Run("setname and getname", func(t *testing.T) {
+		s := RunT(t)
+		c, err := proto.Dial(s.Addr())
+		ok(t, err)
+		defer c.Close()
+
+		// Set the client name
+		mustDo(t, c,
+			"CLIENT", "SETNAME", "miniredis-tests",
+			proto.Inline("OK"),
+		)
+
+		// Get the client name
+		mustDo(t, c,
+			"CLIENT", "GETNAME",
+			proto.String("miniredis-tests"),
+		)
+	})
+
+	t.Run("getname without setname", func(t *testing.T) {
+		s := RunT(t)
+		c, err := proto.Dial(s.Addr())
+		ok(t, err)
+		defer c.Close()
+
+		// Get the client name without setting it first
+		mustDo(t, c,
+			"CLIENT", "GETNAME",
+			proto.Nil,
+		)
+	})
+}

--- a/integration/generic_test.go
+++ b/integration/generic_test.go
@@ -459,16 +459,31 @@ func TestCopy(t *testing.T) {
 func TestClient(t *testing.T) {
 	skip(t)
 	testRaw(t, func(c *client) {
-		// Set the client name
-		c.Do("CLIENT", "SETNAME", "miniredis-tests")
-
-		// Get the client name
-		c.Do("CLIENT", "GETNAME")
-
 		// Try to get the client name without setting it first
 		c.Do("CLIENT", "GETNAME")
 
-		// Try to execute the CLIENT command with no arguments
+		c.Do("CLIENT", "SETNAME", "miniredis-tests")
+		c.Do("CLIENT", "GETNAME")
+		c.Do("CLIENT", "SETNAME", "miniredis-tests2")
+		c.Do("CLIENT", "GETNAME")
+		c.Do("CLIENT", "SETNAME", "")
+		c.Do("CLIENT", "GETNAME")
+
 		c.Error("wrong number", "CLIENT")
+		c.Error("unknown subcommand", "CLIENT", "FOOBAR")
+		c.Error("wrong number", "CLIENT", "GETNAME", "foo")
+		c.Error("contain spaces", "CLIENT", "SETNAME", "miniredis tests")
+		c.Error("contain spaces", "CLIENT", "SETNAME", "miniredis\ntests")
 	})
+
+	testRaw2(t, func(c1, c2 *client) {
+		c1.Do("MULTI")
+		c1.Do("CLIENT", "SETNAME", "conn-c1")
+		c1.Do("CLIENT", "GETNAME")
+		c2.Do("CLIENT", "GETNAME") // not set yet
+		c1.Do("EXEC")
+		c1.Do("CLIENT", "GETNAME")
+		c2.Do("CLIENT", "GETNAME")
+	})
+
 }

--- a/integration/generic_test.go
+++ b/integration/generic_test.go
@@ -455,3 +455,20 @@ func TestCopy(t *testing.T) {
 		})
 	})
 }
+
+func TestClient(t *testing.T) {
+	skip(t)
+	testRaw(t, func(c *client) {
+		// Set the client name
+		c.Do("CLIENT", "SETNAME", "miniredis-tests")
+
+		// Get the client name
+		c.Do("CLIENT", "GETNAME")
+
+		// Try to get the client name without setting it first
+		c.Do("CLIENT", "GETNAME")
+
+		// Try to execute the CLIENT command with no arguments
+		c.Error("wrong number", "CLIENT")
+	})
+}

--- a/miniredis.go
+++ b/miniredis.go
@@ -196,6 +196,7 @@ func (m *Miniredis) start(s *server.Server) error {
 	commandsGeo(m)
 	commandsCluster(m)
 	commandsHll(m)
+	commandsClient(m)
 
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -247,6 +247,7 @@ type Peer struct {
 	Ctx          interface{} // anything goes, server won't touch this
 	onDisconnect []func()    // list of callbacks
 	mu           sync.Mutex  // for Block()
+	ClientName   string      // client name set by CLIENT SETNAME
 }
 
 func NewPeer(w *bufio.Writer) *Peer {


### PR DESCRIPTION
This is an attempt to add [CLIENT SETNAME](https://redis.io/commands/client-setname/) and [CLIENT GETNAME](https://redis.io/commands/client-getname/) as discussed in https://github.com/alicebob/miniredis/issues/340

I've added a new field `ClientName` to the Peer struct in order to track the clients. I am not sure if this approach is fine or not. Please let me know! 