### PR TITLE
Add PEXPIRETIME command

### DIFF
--- a/cmd_generic_test.go
+++ b/cmd_generic_test.go
@@ -388,6 +388,32 @@ func TestExpireTime(t *testing.T) {
 	})
 }
 
+func TestPExpireTime(t *testing.T) {
+	s, err := Run()
+	ok(t, err)
+	defer s.Close()
+	c, err := proto.Dial(s.Addr())
+	ok(t, err)
+	defer c.Close()
+
+	t.Run("nosuch", func(t *testing.T) {
+		mustDo(t, c, "PEXPIRETIME", "nosuch", proto.Int(-2))
+	})
+
+	t.Run("noexpire", func(t *testing.T) {
+		s.Set("noexpire", "")
+		mustDo(t, c, "PEXPIRETIME", "noexpire", proto.Int(-1))
+	})
+
+	t.Run("", func(t *testing.T) {
+		s.Set("foo", "")
+		must1(t, c, "PEXPIREAT", "foo", "10413792000123") // Mon Jan 01 2300 00:00:00.123 GMT+0000
+		mustDo(t, c, "PEXPIRETIME", "foo",
+			proto.Int(10413792000123),
+		)
+	})
+}
+
 func TestExists(t *testing.T) {
 	s, err := Run()
 	ok(t, err)

--- a/integration/string_test.go
+++ b/integration/string_test.go
@@ -168,9 +168,11 @@ func TestExpire(t *testing.T) {
 	skip(t)
 	testRaw(t, func(c *client) {
 		c.Do("EXPIRETIME", "missing")
+		c.Do("PEXPIRETIME", "missing")
 
 		c.Do("SET", "foo", "bar")
 		c.Do("EXPIRETIME", "foo")
+		c.Do("PEXPIRETIME", "foo")
 
 		c.Do("EXPIRE", "foo", "12")
 		c.Do("TTL", "foo")
@@ -178,8 +180,9 @@ func TestExpire(t *testing.T) {
 		c.Do("SET", "foo", "bar")
 		c.Do("PEXPIRE", "foo", "999999")
 		c.Do("EXPIREAT", "foo", "2234567890")
+		c.Do("PEXPIREAT", "foo", "2234567890123")
 		c.Do("EXPIRETIME", "foo")
-		c.Do("PEXPIREAT", "foo", "2234567890000")
+		c.Do("PEXPIRETIME", "foo")
 		// c.Do("PTTL", "foo")
 		c.Do("PTTL", "nosuch")
 
@@ -229,6 +232,8 @@ func TestExpire(t *testing.T) {
 
 		c.Error("wrong number", "EXPIRETIME")
 		c.Error("wrong number", "EXPIRETIME", "too", "many")
+		c.Error("wrong number", "PEXPIRETIME")
+		c.Error("wrong number", "PEXPIRETIME", "too", "many")
 	})
 }
 


### PR DESCRIPTION
Redis documentation: https://redis.io/commands/pexpiretime/

**NOTE:** turning off whitespace changes during review might speed it up a little due to change of `cmdExpireTime` -> `makeCmdExpireTime`