### PR TITLE
Fix integer overflow

### DIFF
--- a/cmd_string_test.go
+++ b/cmd_string_test.go
@@ -479,6 +479,15 @@ func TestIncr(t *testing.T) {
 		assert(t, err != nil, "do s.Incr error")
 	}
 
+	// Overflow
+	{
+		s.Set("overflow", "9223372036854775807")
+		mustDo(t, c,
+			"INCR", "overflow",
+			proto.Error(msgIntOverflow),
+		)
+	}
+
 	// Wrong usage
 	{
 		mustDo(t, c,
@@ -542,6 +551,20 @@ func TestIncrBy(t *testing.T) {
 		"INCRBY", "key", "noint",
 		proto.Error(msgInvalidInt),
 	)
+
+	// Overflow
+	{
+		s.Set("overflow", "10")
+		mustDo(t, c,
+			"INCRBY", "overflow", "9223372036854775807",
+			proto.Error(msgIntOverflow),
+		)
+		s.Set("overflow", "-10")
+		mustDo(t, c,
+			"INCRBY", "overflow", "-9223372036854775807",
+			proto.Error(msgIntOverflow),
+		)
+	}
 
 	// Wrong usage
 	{
@@ -684,6 +707,20 @@ func TestDecrBy(t *testing.T) {
 		proto.Error(msgInvalidInt),
 	)
 
+	// Overflow
+	{
+		s.Set("overflow", "10")
+		mustDo(t, c,
+			"DECRBY", "overflow", "-9223372036854775807",
+			proto.Error(msgIntOverflow),
+		)
+		s.Set("overflow", "-10")
+		mustDo(t, c,
+			"DECRBY", "overflow", "9223372036854775807",
+			proto.Error(msgIntOverflow),
+		)
+	}
+
 	// Wrong usage
 	{
 		mustDo(t, c,
@@ -751,6 +788,15 @@ func TestDecr(t *testing.T) {
 		mustDo(t, c,
 			"DECR", "new", "key",
 			proto.Error(errWrongNumber("decr")),
+		)
+	}
+
+	// Overflow
+	{
+		s.Set("overflow", "-9223372036854775808")
+		mustDo(t, c,
+			"DECR", "overflow",
+			proto.Error(msgIntOverflow),
 		)
 	}
 

--- a/direct.go
+++ b/direct.go
@@ -21,6 +21,9 @@ var (
 	// ErrIntValueError can returned by INCRBY
 	ErrIntValueError = errors.New(msgInvalidInt)
 
+	// ErrIntValueOverflowError can be returned by INCR, DECR, INCRBY, DECRBY
+	ErrIntValueOverflowError = errors.New(msgIntOverflow)
+
 	// ErrFloatValueError can returned by INCRBYFLOAT
 	ErrFloatValueError = errors.New(msgInvalidFloat)
 )

--- a/integration/string_test.go
+++ b/integration/string_test.go
@@ -410,6 +410,17 @@ func TestIncrAndFriends(t *testing.T) {
 		c.Do("INCRBYFLOAT", "zero", "12.3")
 		c.Do("INCRBYFLOAT", "zero", "-13.1")
 
+		// Overflow
+		c.Do("SET", "overflow-up", "9223372036854775807")
+		c.Error("increment or decrement would overflow", "INCR", "overflow-up")
+		c.Error("increment or decrement would overflow", "INCRBY", "overflow-up", "1")
+		c.Error("increment or decrement would overflow", "DECRBY", "overflow-up", "-1")
+
+		c.Do("SET", "overflow-down", "-9223372036854775808")
+		c.Error("increment or decrement would overflow", "DECR", "overflow-down")
+		c.Error("increment or decrement would overflow", "INCRBY", "overflow-down", "-1")
+		c.Error("increment or decrement would overflow", "DECRBY", "overflow-down", "1")
+
 		// E
 		c.Do("INCRBYFLOAT", "one", "12e12")
 		// c.Do("INCRBYFLOAT", "one", "12e34") // FIXME

--- a/redis.go
+++ b/redis.go
@@ -16,6 +16,7 @@ const (
 	msgWrongType            = "WRONGTYPE Operation against a key holding the wrong kind of value"
 	msgNotValidHllValue     = "WRONGTYPE Key is not a valid HyperLogLog string value."
 	msgInvalidInt           = "ERR value is not an integer or out of range"
+	msgIntOverflow          = "ERR increment or decrement would overflow"
 	msgInvalidFloat         = "ERR value is not a valid float"
 	msgInvalidMinMax        = "ERR min or max is not a float"
 	msgInvalidRangeItem     = "ERR min or max not valid string range item"


### PR DESCRIPTION
Fixes INCR, DECR, INCRBY, DECRBY to return error when value would overflow.

Closes: https://github.com/alicebob/miniredis/issues/291