### PR TITLE
upgrade to redis 7.2.4, which is the last released under BSD-3 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Commands which will probably not be implemented:
 
 ## &c.
 
-Integration tests are run against Redis 7.2.0. The [./integration](./integration/) subdir
+Integration tests are run against Redis 7.2.4. The [./integration](./integration/) subdir
 compares miniredis against a real redis instance.
 
 The Redis 6 RESP3 protocol is supported. If there are problems, please open

--- a/integration/get_redis.sh
+++ b/integration/get_redis.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-VERSION=7.2.0
+VERSION=7.2.4
 
 rm -rf ./redis_src/
 mkdir -p ./redis_src/


### PR DESCRIPTION
Redis has its license changed in v7.4. Which is their right to do, but for now I'll keep miniredis at aiming for 7.2.4 behavior.

https://lobste.rs/s/sbuqgf/redis_dropped_bsd_3_favor_proprietary