### PR TITLE
make go 1.17 the minimum version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.14', '1.20', '1.21', '1.22' ]
+        go: [ '1.17', '1.20', '1.21', '1.22' ]
     name: Go ${{ matrix.go }}
     steps:
     - uses: actions/checkout@v4

--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -25,10 +25,7 @@ func inSeconds(t time.Time) int {
 }
 
 func inMilliSeconds(t time.Time) int {
-	// Time.UnixMilli() was added in go 1.17
-	// return int(t.UnixNano() / 1000000) is limited to dates between year 1678 and 2262
-	// by using following calculation we extend this time without too much complexity
-	return int(t.Unix())*1000 + t.Nanosecond()/1000000
+	return int(t.UnixMilli())
 }
 
 // commandsGeneric handles EXPIRE, TTL, PERSIST, &c.

--- a/cmd_stream.go
+++ b/cmd_stream.go
@@ -1665,7 +1665,7 @@ func (m *Miniredis) cmdXclaim(c *server.Peer, cmd string, args []string) {
 				c.WriteError("ERR Invalid TIME option argument for XCLAIM")
 				return
 			}
-			opts.newLastDelivery = unixMilli(timeMs)
+			opts.newLastDelivery = time.UnixMilli(timeMs)
 			args = args[2:]
 		case "RETRYCOUNT":
 			retryCount, err := strconv.Atoi(args[1])
@@ -1805,9 +1805,4 @@ func parseBlock(cmd string, args []string, block *bool, timeout *time.Duration) 
 	}
 	(*timeout) = time.Millisecond * time.Duration(ms)
 	return nil
-}
-
-// taken from Go's time package. Can be dropped if miniredis supports >= 1.17
-func unixMilli(msec int64) time.Time {
-	return time.Unix(msec/1e3, (msec%1e3)*1e6)
 }

--- a/db.go
+++ b/db.go
@@ -3,17 +3,11 @@ package miniredis
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sort"
 	"strconv"
 	"time"
-)
-
-const (
-	intSize = 32 << (^uint(0) >> 63) // 32 or 64
-
-	maxInt = 1<<(intSize-1) - 1  // [math.MaxInt] was added in go 1.17
-	minInt = -1 << (intSize - 1) // [math.MinInt] was added in go 1.17
 )
 
 var (
@@ -189,11 +183,11 @@ func (db *RedisDB) stringIncr(k string, delta int) (int, error) {
 	}
 
 	if delta > 0 {
-		if maxInt-delta < v {
+		if math.MaxInt-delta < v {
 			return 0, ErrIntValueOverflowError
 		}
 	} else {
-		if minInt-delta > v {
+		if math.MinInt-delta > v {
 			return 0, ErrIntValueOverflowError
 		}
 	}

--- a/fpconv/fuzz_test.go
+++ b/fpconv/fuzz_test.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.18
+// +build go1.18
 
 package fpconv
 

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 )
 
-go 1.14
+go 1.17


### PR DESCRIPTION
There are too many small workarounds.

For example the one used in #361.