### PR TITLE
Tests cleanup

### DIFF
--- a/cmd_client_test.go
+++ b/cmd_client_test.go
@@ -9,10 +9,7 @@ import (
 // Test CLIENT *.
 func TestClient(t *testing.T) {
 	t.Run("setname and getname", func(t *testing.T) {
-		s := RunT(t)
-		c, err := proto.Dial(s.Addr())
-		ok(t, err)
-		defer c.Close()
+		_, c := runWithClient(t)
 
 		// Set the client name
 		mustDo(t, c,
@@ -28,10 +25,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("getname without setname", func(t *testing.T) {
-		s := RunT(t)
-		c, err := proto.Dial(s.Addr())
-		ok(t, err)
-		defer c.Close()
+		_, c := runWithClient(t)
 
 		// Get the client name without setting it first
 		mustDo(t, c,

--- a/cmd_cluster_test.go
+++ b/cmd_cluster_test.go
@@ -9,10 +9,7 @@ import (
 
 // Test CLUSTER *.
 func TestCluster(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("slots", func(t *testing.T) {
 		port, err := strconv.Atoi(s.Port())

--- a/cmd_connection_test.go
+++ b/cmd_connection_test.go
@@ -8,10 +8,7 @@ import (
 
 func TestAuth(t *testing.T) {
 	t.Run("default user", func(t *testing.T) {
-		s := RunT(t)
-		c, err := proto.Dial(s.Addr())
-		ok(t, err)
-		defer c.Close()
+		s, c := runWithClient(t)
 
 		mustDo(t, c,
 			"AUTH", "foo", "bar", "baz",
@@ -38,10 +35,7 @@ func TestAuth(t *testing.T) {
 	})
 
 	t.Run("another user", func(t *testing.T) {
-		s := RunT(t)
-		c, err := proto.Dial(s.Addr())
-		ok(t, err)
-		defer c.Close()
+		s, c := runWithClient(t)
 
 		s.RequireUserAuth("hello", "world")
 		mustDo(t, c,
@@ -67,10 +61,7 @@ func TestAuth(t *testing.T) {
 	})
 
 	t.Run("error cases", func(t *testing.T) {
-		s := RunT(t)
-		c, err := proto.Dial(s.Addr())
-		ok(t, err)
-		defer c.Close()
+		_, c := runWithClient(t)
 
 		mustDo(t, c,
 			"AUTH",
@@ -85,10 +76,7 @@ func TestAuth(t *testing.T) {
 }
 
 func TestPing(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	t.Run("no args", func(t *testing.T) {
 		mustDo(t, c,
@@ -113,10 +101,7 @@ func TestPing(t *testing.T) {
 }
 
 func TestEcho(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"ECHO", "hello\nworld",
@@ -130,10 +115,7 @@ func TestEcho(t *testing.T) {
 }
 
 func TestSelect(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	mustOK(t, c, "SET", "foo", "bar")
 	mustOK(t, c, "SELECT", "5")
@@ -161,10 +143,7 @@ func TestSelect(t *testing.T) {
 }
 
 func TestSwapdb(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	mustOK(t, c, "SET", "foo", "bar")
 	mustOK(t, c, "SELECT", "5")
@@ -224,10 +203,7 @@ func TestSwapdb(t *testing.T) {
 }
 
 func TestQuit(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustOK(t, c, "QUIT")
 
@@ -237,10 +213,7 @@ func TestQuit(t *testing.T) {
 }
 
 func TestSetError(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	mustDo(t, c,
 		"PING",
@@ -262,10 +235,7 @@ func TestSetError(t *testing.T) {
 
 func TestHello(t *testing.T) {
 	t.Run("default user", func(t *testing.T) {
-		s := RunT(t)
-		c, err := proto.Dial(s.Addr())
-		ok(t, err)
-		defer c.Close()
+		s, c := runWithClient(t)
 
 		payl := proto.Map(
 			proto.String("server"), proto.String("miniredis"),

--- a/cmd_connection_test.go
+++ b/cmd_connection_test.go
@@ -8,9 +8,7 @@ import (
 
 func TestAuth(t *testing.T) {
 	t.Run("default user", func(t *testing.T) {
-		s, err := Run()
-		ok(t, err)
-		defer s.Close()
+		s := RunT(t)
 		c, err := proto.Dial(s.Addr())
 		ok(t, err)
 		defer c.Close()
@@ -40,9 +38,7 @@ func TestAuth(t *testing.T) {
 	})
 
 	t.Run("another user", func(t *testing.T) {
-		s, err := Run()
-		ok(t, err)
-		defer s.Close()
+		s := RunT(t)
 		c, err := proto.Dial(s.Addr())
 		ok(t, err)
 		defer c.Close()
@@ -71,9 +67,7 @@ func TestAuth(t *testing.T) {
 	})
 
 	t.Run("error cases", func(t *testing.T) {
-		s, err := Run()
-		ok(t, err)
-		defer s.Close()
+		s := RunT(t)
 		c, err := proto.Dial(s.Addr())
 		ok(t, err)
 		defer c.Close()
@@ -91,9 +85,7 @@ func TestAuth(t *testing.T) {
 }
 
 func TestPing(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -121,9 +113,7 @@ func TestPing(t *testing.T) {
 }
 
 func TestEcho(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -140,9 +130,7 @@ func TestEcho(t *testing.T) {
 }
 
 func TestSelect(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -173,9 +161,7 @@ func TestSelect(t *testing.T) {
 }
 
 func TestSwapdb(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -238,9 +224,7 @@ func TestSwapdb(t *testing.T) {
 }
 
 func TestQuit(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -253,9 +237,7 @@ func TestQuit(t *testing.T) {
 }
 
 func TestSetError(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -280,9 +262,7 @@ func TestSetError(t *testing.T) {
 
 func TestHello(t *testing.T) {
 	t.Run("default user", func(t *testing.T) {
-		s, err := Run()
-		ok(t, err)
-		defer s.Close()
+		s := RunT(t)
 		c, err := proto.Dial(s.Addr())
 		ok(t, err)
 		defer c.Close()

--- a/cmd_generic_test.go
+++ b/cmd_generic_test.go
@@ -10,10 +10,7 @@ import (
 
 // Test EXPIRE. Keys with an expiration are called volatile in Redis parlance.
 func TestTTL(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("parse", func(t *testing.T) {
 		t.Run("basic", func(t *testing.T) {
@@ -102,10 +99,7 @@ func TestTTL(t *testing.T) {
 }
 
 func TestExpireat(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Not volatile yet
 	{
@@ -136,10 +130,7 @@ func TestExpireat(t *testing.T) {
 }
 
 func TestTouch(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Set something
 	t.Run("basic", func(t *testing.T) {
@@ -176,10 +167,7 @@ func TestTouch(t *testing.T) {
 }
 
 func TestPexpireat(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Not volatile yet
 	{
@@ -212,10 +200,7 @@ func TestPexpireat(t *testing.T) {
 }
 
 func TestPexpire(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("key exists", func(t *testing.T) {
 		ok(t, s.Set("foo", "bar"))
@@ -246,10 +231,7 @@ func TestPexpire(t *testing.T) {
 }
 
 func TestDel(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("simple", func(t *testing.T) {
 		s.Set("foo", "bar")
@@ -281,10 +263,7 @@ func TestDel(t *testing.T) {
 }
 
 func TestUnlink(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("simple", func(t *testing.T) {
 		s.Set("foo", "bar")
@@ -309,10 +288,7 @@ func TestUnlink(t *testing.T) {
 }
 
 func TestType(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Set("foo", "bar!")
 	t.Run("string", func(t *testing.T) {
@@ -355,10 +331,7 @@ func TestType(t *testing.T) {
 }
 
 func TestExpireTime(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("nosuch", func(t *testing.T) {
 		mustDo(t, c, "EXPIRETIME", "nosuch", proto.Int(-2))
@@ -379,10 +352,7 @@ func TestExpireTime(t *testing.T) {
 }
 
 func TestPExpireTime(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("nosuch", func(t *testing.T) {
 		mustDo(t, c, "PEXPIRETIME", "nosuch", proto.Int(-2))
@@ -403,10 +373,7 @@ func TestPExpireTime(t *testing.T) {
 }
 
 func TestExists(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("string", func(t *testing.T) {
 		s.Set("foo", "bar!")
@@ -448,10 +415,7 @@ func TestExists(t *testing.T) {
 }
 
 func TestMove(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// No problem.
 	{
@@ -501,10 +465,7 @@ func TestMove(t *testing.T) {
 }
 
 func TestKeys(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Set("foo", "bar!")
 	s.Set("foobar", "bar!")
@@ -547,10 +508,7 @@ func TestKeys(t *testing.T) {
 }
 
 func TestRandom(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Empty db.
 	mustNil(t, c, "RANDOMKEY")
@@ -575,10 +533,7 @@ func TestRandom(t *testing.T) {
 }
 
 func TestRename(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Non-existing key
 	mustDo(t, c,
@@ -652,10 +607,7 @@ func TestRename(t *testing.T) {
 }
 
 func TestScan(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("parse", func(t *testing.T) {
 		t.Run("basic", func(t *testing.T) {
@@ -816,10 +768,7 @@ func TestScan(t *testing.T) {
 }
 
 func TestRenamenx(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Non-existing key
 	mustDo(t, c,
@@ -871,10 +820,7 @@ func TestRenamenx(t *testing.T) {
 }
 
 func TestCopy(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("parse", func(t *testing.T) {
 		t.Run("basic", func(t *testing.T) {

--- a/cmd_generic_test.go
+++ b/cmd_generic_test.go
@@ -10,9 +10,7 @@ import (
 
 // Test EXPIRE. Keys with an expiration are called volatile in Redis parlance.
 func TestTTL(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -104,9 +102,7 @@ func TestTTL(t *testing.T) {
 }
 
 func TestExpireat(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -140,9 +136,7 @@ func TestExpireat(t *testing.T) {
 }
 
 func TestTouch(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -182,9 +176,7 @@ func TestTouch(t *testing.T) {
 }
 
 func TestPexpireat(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -220,9 +212,7 @@ func TestPexpireat(t *testing.T) {
 }
 
 func TestPexpire(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -256,9 +246,7 @@ func TestPexpire(t *testing.T) {
 }
 
 func TestDel(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -293,9 +281,7 @@ func TestDel(t *testing.T) {
 }
 
 func TestUnlink(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -323,9 +309,7 @@ func TestUnlink(t *testing.T) {
 }
 
 func TestType(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -371,9 +355,7 @@ func TestType(t *testing.T) {
 }
 
 func TestExpireTime(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -397,9 +379,7 @@ func TestExpireTime(t *testing.T) {
 }
 
 func TestPExpireTime(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -423,9 +403,7 @@ func TestPExpireTime(t *testing.T) {
 }
 
 func TestExists(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -470,9 +448,7 @@ func TestExists(t *testing.T) {
 }
 
 func TestMove(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -525,9 +501,7 @@ func TestMove(t *testing.T) {
 }
 
 func TestKeys(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -573,9 +547,7 @@ func TestKeys(t *testing.T) {
 }
 
 func TestRandom(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -603,9 +575,7 @@ func TestRandom(t *testing.T) {
 }
 
 func TestRename(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -682,9 +652,7 @@ func TestRename(t *testing.T) {
 }
 
 func TestScan(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -848,9 +816,7 @@ func TestScan(t *testing.T) {
 }
 
 func TestRenamenx(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -905,9 +871,7 @@ func TestRenamenx(t *testing.T) {
 }
 
 func TestCopy(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_geo_test.go
+++ b/cmd_geo_test.go
@@ -7,10 +7,7 @@ import (
 )
 
 func TestGeoadd(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	t.Run("ok", func(t *testing.T) {
 		must1(t, c, "GEOADD", "Sicily", "13.361389", "38.115556", "Palermo")
@@ -47,10 +44,7 @@ func TestGeoadd(t *testing.T) {
 }
 
 func TestGeopos(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	must1(t, c, "GEOADD", "Sicily", "13.361389", "38.115556", "Palermo")
 
@@ -85,10 +79,7 @@ func TestGeopos(t *testing.T) {
 
 // Test GEOADD / GEORADIUS / GEORADIUS_RO
 func TestGeo(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	must1(t, c, "GEOADD", "Sicily", "13.361389", "38.115556", "Palermo")
 	must1(t, c, "GEOADD", "Sicily", "15.087269", "37.502669", "Catania")
@@ -242,10 +233,7 @@ func TestGeo(t *testing.T) {
 }
 
 func TestGeodist(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	must1(t, c, "GEOADD", "Sicily", "13.361389", "38.115556", "Palermo")
 	must1(t, c, "GEOADD", "Sicily", "15.087269", "37.502669", "Catania")
@@ -297,10 +285,7 @@ func TestGeodist(t *testing.T) {
 
 // Test GEOADD / GEORADIUSBYMEMBER / GEORADIUSBYMEMBER_RO
 func TestGeobymember(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	must1(t, c, "GEOADD", "Sicily", "13.361389", "38.115556", "Palermo")
 	must1(t, c, "GEOADD", "Sicily", "15.087269", "37.502669", "Catania")

--- a/cmd_geo_test.go
+++ b/cmd_geo_test.go
@@ -7,9 +7,7 @@ import (
 )
 
 func TestGeoadd(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -49,9 +47,7 @@ func TestGeoadd(t *testing.T) {
 }
 
 func TestGeopos(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -89,9 +85,7 @@ func TestGeopos(t *testing.T) {
 
 // Test GEOADD / GEORADIUS / GEORADIUS_RO
 func TestGeo(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -248,9 +242,7 @@ func TestGeo(t *testing.T) {
 }
 
 func TestGeodist(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -305,9 +297,7 @@ func TestGeodist(t *testing.T) {
 
 // Test GEOADD / GEORADIUSBYMEMBER / GEORADIUSBYMEMBER_RO
 func TestGeobymember(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_hash_test.go
+++ b/cmd_hash_test.go
@@ -9,10 +9,7 @@ import (
 )
 
 func TestHash(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	must1(t, c, "HSET", "aap", "noot", "mies")
 
@@ -95,10 +92,7 @@ func TestHash(t *testing.T) {
 }
 
 func TestHashSetNX(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// New Hash
 	must1(t, c, "HSETNX", "wim", "zus", "jet")
@@ -117,10 +111,7 @@ func TestHashSetNX(t *testing.T) {
 }
 
 func TestHashMSet(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// New Hash
 	{
@@ -150,10 +141,7 @@ func TestHashMSet(t *testing.T) {
 }
 
 func TestHashDel(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.HSet("wim", "zus", "jet")
 	s.HSet("wim", "teun", "vuur")
@@ -181,10 +169,7 @@ func TestHashDel(t *testing.T) {
 }
 
 func TestHashExists(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.HSet("wim", "zus", "jet")
 	s.HSet("wim", "teun", "vuur")
@@ -201,10 +186,7 @@ func TestHashExists(t *testing.T) {
 }
 
 func TestHashGetall(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.HSet("wim", "zus", "jet")
 	s.HSet("wim", "teun", "vuur")
@@ -248,10 +230,7 @@ func TestHashGetall(t *testing.T) {
 }
 
 func TestHashKeys(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.HSet("wim", "zus", "jet")
 	s.HSet("wim", "teun", "vuur")
@@ -288,10 +267,7 @@ func TestHashKeys(t *testing.T) {
 }
 
 func TestHashValues(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.HSet("wim", "zus", "jet")
 	s.HSet("wim", "teun", "vuur")
@@ -314,10 +290,7 @@ func TestHashValues(t *testing.T) {
 }
 
 func TestHashLen(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.HSet("wim", "zus", "jet")
 	s.HSet("wim", "teun", "vuur")
@@ -333,10 +306,7 @@ func TestHashLen(t *testing.T) {
 }
 
 func TestHashMget(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.HSet("wim", "zus", "jet")
 	s.HSet("wim", "teun", "vuur")
@@ -368,10 +338,7 @@ func TestHashMget(t *testing.T) {
 }
 
 func TestHashIncrby(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// New key
 	must1(t, c, "HINCRBY", "hash", "field", "1")
@@ -414,10 +381,7 @@ func TestHashIncrby(t *testing.T) {
 }
 
 func TestHashIncrbyfloat(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Existing key
 	{
@@ -485,10 +449,7 @@ func TestHashIncrbyfloat(t *testing.T) {
 }
 
 func TestHscan(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// We cheat with hscan. It always returns everything.
 
@@ -576,10 +537,7 @@ func TestHscan(t *testing.T) {
 }
 
 func TestHstrlen(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("basic", func(t *testing.T) {
 		s.HSet("myhash", "foo", "bar")
@@ -636,10 +594,7 @@ func TestHstrlen(t *testing.T) {
 }
 
 func TestHashRandField(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.HSet("wim", "zus", "jet")
 	s.HSet("wim", "teun", "vuur")

--- a/cmd_hll_test.go
+++ b/cmd_hll_test.go
@@ -8,10 +8,7 @@ import (
 
 // Test PFADD
 func TestPfadd(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	mustDo(t, c,
 		"PFADD", "h", "aap", "noot", "mies",
@@ -54,10 +51,7 @@ func TestPfadd(t *testing.T) {
 
 // Test PFCOUNT
 func TestPfcount(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Add 100 unique random values
 	for i := 0; i < 100; i++ {
@@ -131,10 +125,7 @@ func TestPfcount(t *testing.T) {
 
 // Test PFMERGE
 func TestPfmerge(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Add 100 unique random values to h1 and 50 of these 100 to h2
 	for i := 0; i < 100; i++ {

--- a/cmd_hll_test.go
+++ b/cmd_hll_test.go
@@ -8,9 +8,7 @@ import (
 
 // Test PFADD
 func TestPfadd(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -56,9 +54,7 @@ func TestPfadd(t *testing.T) {
 
 // Test PFCOUNT
 func TestPfcount(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -135,9 +131,7 @@ func TestPfcount(t *testing.T) {
 
 // Test PFMERGE
 func TestPfmerge(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_info_test.go
+++ b/cmd_info_test.go
@@ -8,9 +8,7 @@ import (
 )
 
 func TestMiniredis_cmdInfo(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)

--- a/cmd_info_test.go
+++ b/cmd_info_test.go
@@ -8,11 +8,7 @@ import (
 )
 
 func TestMiniredis_cmdInfo(t *testing.T) {
-	s := RunT(t)
-
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("Invalid section name", func(t *testing.T) {
 		mustDo(t, c,

--- a/cmd_list_test.go
+++ b/cmd_list_test.go
@@ -28,10 +28,7 @@ func goStrings(t *testing.T, s *Miniredis, args ...string) <-chan string {
 }
 
 func TestLpush(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("basic", func(t *testing.T) {
 		mustDo(t, c,
@@ -118,10 +115,7 @@ func TestLpush(t *testing.T) {
 }
 
 func TestLpushx(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		must0(t, c,
@@ -183,10 +177,7 @@ func TestLpushx(t *testing.T) {
 }
 
 func TestLpop(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	t.Run("single", func(t *testing.T) {
 		mustDo(t, c,
@@ -266,10 +257,7 @@ func TestLpop(t *testing.T) {
 }
 
 func TestRPushPop(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		mustDo(t, c,
@@ -339,10 +327,7 @@ func TestRPushPop(t *testing.T) {
 }
 
 func TestRpop(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Push("l", "aap", "noot", "mies")
 
@@ -372,10 +357,7 @@ func TestRpop(t *testing.T) {
 }
 
 func TestLindex(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Push("l", "aap", "noot", "mies", "vuur")
 
@@ -431,10 +413,7 @@ func TestLindex(t *testing.T) {
 }
 
 func TestLpos(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Push("l", "aap", "noot", "aap", "mies", "aap", "vuur", "aap", "aap")
 
@@ -687,10 +666,7 @@ func TestLpos(t *testing.T) {
 }
 
 func TestLlen(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Push("l", "aap", "noot", "mies", "vuur")
 
@@ -719,10 +695,7 @@ func TestLlen(t *testing.T) {
 }
 
 func TestLtrim(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Push("l", "aap", "noot", "mies", "vuur")
 
@@ -778,10 +751,7 @@ func TestLtrim(t *testing.T) {
 }
 
 func TestLrem(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Reverse
 	{
@@ -875,10 +845,7 @@ func TestLrem(t *testing.T) {
 }
 
 func TestLset(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Push("l", "aap", "noot", "mies", "vuur", "noot", "noot")
 	// Simple LSET
@@ -945,10 +912,7 @@ func TestLset(t *testing.T) {
 }
 
 func TestLinsert(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Push("l", "aap", "noot", "mies", "vuur", "noot", "end")
 	// Before
@@ -1041,10 +1005,7 @@ func TestLinsert(t *testing.T) {
 }
 
 func TestRpoplpush(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Push("l", "aap", "noot", "mies")
 	s.Push("l2", "vuur", "noot", "end")
@@ -1132,10 +1093,7 @@ func TestRpoplpush(t *testing.T) {
 }
 
 func TestRpushx(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Simple cases
 	{
@@ -1194,10 +1152,7 @@ func TestRpushx(t *testing.T) {
 }
 
 func TestBrpop(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Simple cases
 	{
@@ -1229,10 +1184,7 @@ func TestBrpop(t *testing.T) {
 }
 
 func TestBrpopSimple(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	got := goStrings(t, s, "BRPOP", "mylist", "0")
 	time.Sleep(30 * time.Millisecond)
@@ -1251,10 +1203,7 @@ func TestBrpopSimple(t *testing.T) {
 }
 
 func TestBrpopMulti(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	got := goStrings(t, s, "BRPOP", "l1", "l2", "l3", "0")
 	must1(t, c, "RPUSH", "l0", "e01")
@@ -1279,9 +1228,6 @@ func TestBrpopMulti(t *testing.T) {
 
 func TestBrpopTimeout(t *testing.T) {
 	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
 
 	got := goStrings(t, s, "BRPOP", "l1", "0.1")
 	select {
@@ -1294,10 +1240,7 @@ func TestBrpopTimeout(t *testing.T) {
 
 func TestBrpopTx(t *testing.T) {
 	// BRPOP in a transaction behaves as if the timeout triggers right away
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		mustOK(t, c,
@@ -1347,10 +1290,7 @@ func TestBrpopTx(t *testing.T) {
 }
 
 func TestBlpop(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("basic", func(t *testing.T) {
 		s.Push("ll", "aap", "noot", "mies")
@@ -1398,10 +1338,7 @@ func TestBlpopResourceCleanup(t *testing.T) {
 }
 
 func TestBrpoplpush(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Simple cases
 	{
@@ -1445,10 +1382,7 @@ func TestBrpoplpush(t *testing.T) {
 }
 
 func TestBrpoplpushSimple(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	got := goStrings(t, s, "BRPOPLPUSH", "from", "to", "1")
 	time.Sleep(30 * time.Millisecond)
@@ -1486,10 +1420,7 @@ func TestBrpoplpushTimeout(t *testing.T) {
 }
 
 func TestLmove(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Push("src", "LR", "LL", "RR", "RL")
 	s.Push("dst", "m1", "m2", "m3")
@@ -1615,10 +1546,7 @@ func TestLmove(t *testing.T) {
 }
 
 func TestBlmove(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("Behaves just like LMOVE", func(t *testing.T) {
 		s.Push("src", "LR", "LL", "RR", "RL")

--- a/cmd_list_test.go
+++ b/cmd_list_test.go
@@ -28,9 +28,7 @@ func goStrings(t *testing.T, s *Miniredis, args ...string) <-chan string {
 }
 
 func TestLpush(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -120,9 +118,7 @@ func TestLpush(t *testing.T) {
 }
 
 func TestLpushx(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -187,9 +183,7 @@ func TestLpushx(t *testing.T) {
 }
 
 func TestLpop(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -272,9 +266,7 @@ func TestLpop(t *testing.T) {
 }
 
 func TestRPushPop(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -347,9 +339,7 @@ func TestRPushPop(t *testing.T) {
 }
 
 func TestRpop(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -382,9 +372,7 @@ func TestRpop(t *testing.T) {
 }
 
 func TestLindex(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -443,9 +431,7 @@ func TestLindex(t *testing.T) {
 }
 
 func TestLpos(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -701,9 +687,7 @@ func TestLpos(t *testing.T) {
 }
 
 func TestLlen(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -735,9 +719,7 @@ func TestLlen(t *testing.T) {
 }
 
 func TestLtrim(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -796,9 +778,7 @@ func TestLtrim(t *testing.T) {
 }
 
 func TestLrem(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -895,9 +875,7 @@ func TestLrem(t *testing.T) {
 }
 
 func TestLset(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -967,9 +945,7 @@ func TestLset(t *testing.T) {
 }
 
 func TestLinsert(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1065,9 +1041,7 @@ func TestLinsert(t *testing.T) {
 }
 
 func TestRpoplpush(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1158,9 +1132,7 @@ func TestRpoplpush(t *testing.T) {
 }
 
 func TestRpushx(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1222,9 +1194,7 @@ func TestRpushx(t *testing.T) {
 }
 
 func TestBrpop(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1259,9 +1229,7 @@ func TestBrpop(t *testing.T) {
 }
 
 func TestBrpopSimple(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1283,9 +1251,7 @@ func TestBrpopSimple(t *testing.T) {
 }
 
 func TestBrpopMulti(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1312,9 +1278,7 @@ func TestBrpopMulti(t *testing.T) {
 }
 
 func TestBrpopTimeout(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1330,9 +1294,7 @@ func TestBrpopTimeout(t *testing.T) {
 
 func TestBrpopTx(t *testing.T) {
 	// BRPOP in a transaction behaves as if the timeout triggers right away
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1385,9 +1347,7 @@ func TestBrpopTx(t *testing.T) {
 }
 
 func TestBlpop(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1421,8 +1381,7 @@ func TestBlpop(t *testing.T) {
 }
 
 func TestBlpopResourceCleanup(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 
@@ -1439,9 +1398,7 @@ func TestBlpopResourceCleanup(t *testing.T) {
 }
 
 func TestBrpoplpush(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1488,9 +1445,7 @@ func TestBrpoplpush(t *testing.T) {
 }
 
 func TestBrpoplpushSimple(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1519,9 +1474,7 @@ func TestBrpoplpushSimple(t *testing.T) {
 }
 
 func TestBrpoplpushTimeout(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 
 	got := goStrings(t, s, "BRPOPLPUSH", "l1", "l2", "0.1")
 	select {
@@ -1533,9 +1486,7 @@ func TestBrpoplpushTimeout(t *testing.T) {
 }
 
 func TestLmove(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1664,9 +1615,7 @@ func TestLmove(t *testing.T) {
 }
 
 func TestBlmove(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_object_test.go
+++ b/cmd_object_test.go
@@ -9,9 +9,7 @@ import (
 
 // Test OBJECT IDLETIME.
 func TestObjectIdletime(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_object_test.go
+++ b/cmd_object_test.go
@@ -9,10 +9,7 @@ import (
 
 // Test OBJECT IDLETIME.
 func TestObjectIdletime(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		start := time.Now()

--- a/cmd_pubsub_test.go
+++ b/cmd_pubsub_test.go
@@ -7,10 +7,7 @@ import (
 )
 
 func TestSubscribe(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	mustDo(t, c,
 		"SUBSCRIBE", "event1",
@@ -83,10 +80,7 @@ func TestSubscribe(t *testing.T) {
 }
 
 func TestUnsubscribe(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"SUBSCRIBE", "event1", "event2", "event3", "event4", "event5",
@@ -163,10 +157,7 @@ func TestUnsubscribe(t *testing.T) {
 }
 
 func TestUnsubscribeEmpty(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"UNSUBSCRIBE",
@@ -179,10 +170,7 @@ func TestUnsubscribeEmpty(t *testing.T) {
 }
 
 func TestPsubscribe(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	mustDo(t, c,
 		"PSUBSCRIBE", "event1",
@@ -236,10 +224,7 @@ func TestPsubscribe(t *testing.T) {
 }
 
 func TestPunsubscribe(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"PSUBSCRIBE", "event1", "event2?", "event3*", "event4[abc]", "event5[]",
@@ -292,10 +277,7 @@ func TestPunsubscribe(t *testing.T) {
 }
 
 func TestPunsubscribeEmpty(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"PUNSUBSCRIBE",
@@ -310,10 +292,7 @@ func TestPunsubscribeEmpty(t *testing.T) {
 func TestPublishMode(t *testing.T) {
 	// only pubsub related commands should be accepted while there are
 	// subscriptions.
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"SUBSCRIBE", "birds",
@@ -389,10 +368,7 @@ func TestPublish(t *testing.T) {
 
 func TestPublishMix(t *testing.T) {
 	// SUBSCRIBE and PSUBSCRIBE
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"SUBSCRIBE", "c1",
@@ -528,10 +504,7 @@ func TestPubsubNumsub(t *testing.T) {
 }
 
 func TestPubsubNumpat(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	must0(t, c,
 		"PUBSUB", "NUMPAT",
@@ -541,10 +514,7 @@ func TestPubsubNumpat(t *testing.T) {
 }
 
 func TestPubSubBadArgs(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"SUBSCRIBE",

--- a/cmd_pubsub_test.go
+++ b/cmd_pubsub_test.go
@@ -7,9 +7,7 @@ import (
 )
 
 func TestSubscribe(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -85,9 +83,7 @@ func TestSubscribe(t *testing.T) {
 }
 
 func TestUnsubscribe(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -167,9 +163,7 @@ func TestUnsubscribe(t *testing.T) {
 }
 
 func TestUnsubscribeEmpty(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -185,9 +179,7 @@ func TestUnsubscribeEmpty(t *testing.T) {
 }
 
 func TestPsubscribe(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -244,9 +236,7 @@ func TestPsubscribe(t *testing.T) {
 }
 
 func TestPunsubscribe(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -302,9 +292,7 @@ func TestPunsubscribe(t *testing.T) {
 }
 
 func TestPunsubscribeEmpty(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -322,9 +310,7 @@ func TestPunsubscribeEmpty(t *testing.T) {
 func TestPublishMode(t *testing.T) {
 	// only pubsub related commands should be accepted while there are
 	// subscriptions.
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -359,9 +345,7 @@ func TestPublishMode(t *testing.T) {
 }
 
 func TestPublish(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c1, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c1.Close()
@@ -405,9 +389,7 @@ func TestPublish(t *testing.T) {
 
 func TestPublishMix(t *testing.T) {
 	// SUBSCRIBE and PSUBSCRIBE
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -459,9 +441,7 @@ func TestPublishMix(t *testing.T) {
 }
 
 func TestPubsubChannels(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c1, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c1.Close()
@@ -509,9 +489,7 @@ func TestPubsubChannels(t *testing.T) {
 }
 
 func TestPubsubNumsub(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c1, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c1.Close()
@@ -550,9 +528,7 @@ func TestPubsubNumsub(t *testing.T) {
 }
 
 func TestPubsubNumpat(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -565,9 +541,7 @@ func TestPubsubNumpat(t *testing.T) {
 }
 
 func TestPubSubBadArgs(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_scripting_test.go
+++ b/cmd_scripting_test.go
@@ -7,9 +7,7 @@ import (
 )
 
 func TestEval(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -92,9 +90,7 @@ func TestEval(t *testing.T) {
 }
 
 func TestEvalCall(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -116,9 +112,7 @@ func TestEvalCall(t *testing.T) {
 }
 
 func TestScript(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -188,9 +182,7 @@ func TestScript(t *testing.T) {
 }
 
 func TestCJSON(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -227,9 +219,7 @@ func TestCJSON(t *testing.T) {
 }
 
 func TestLog(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -238,9 +228,7 @@ func TestLog(t *testing.T) {
 }
 
 func TestSha1Hex(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -274,9 +262,7 @@ func TestSha1Hex(t *testing.T) {
 }
 
 func TestEvalsha(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -328,9 +314,7 @@ func TestEvalsha(t *testing.T) {
 }
 
 func TestCmdEvalReply(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -473,9 +457,7 @@ func TestCmdEvalReply(t *testing.T) {
 }
 
 func TestCmdEvalResponse(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -518,9 +500,7 @@ func TestCmdEvalResponse(t *testing.T) {
 }
 
 func TestCmdEvalAuth(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -544,9 +524,7 @@ func TestCmdEvalAuth(t *testing.T) {
 }
 
 func TestLuaReplicate(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -557,9 +535,7 @@ func TestLuaReplicate(t *testing.T) {
 }
 
 func TestLuaTX(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_scripting_test.go
+++ b/cmd_scripting_test.go
@@ -7,10 +7,7 @@ import (
 )
 
 func TestEval(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"EVAL", "return 42", "0",
@@ -82,7 +79,6 @@ func TestEval(t *testing.T) {
 		must0(t, c,
 			"EVAL", "return redis.call('expire','foo', 999999)", "0",
 		)
-		ok(t, err)
 		must0(t, c,
 			"EVAL", "return redis.call('expire','foo',1000000)", "0",
 		)
@@ -90,10 +86,7 @@ func TestEval(t *testing.T) {
 }
 
 func TestEvalCall(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustContain(t, c,
 		"EVAL", "redis.call()", "0",
@@ -112,10 +105,7 @@ func TestEvalCall(t *testing.T) {
 }
 
 func TestScript(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	var (
 		script1sha = "a42059b356c875f0717db19a51f6aaca9ae659ea"
@@ -182,10 +172,7 @@ func TestScript(t *testing.T) {
 }
 
 func TestCJSON(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"EVAL", `return cjson.decode('{"id":"foo"}')['id']`, "0",
@@ -219,19 +206,13 @@ func TestCJSON(t *testing.T) {
 }
 
 func TestLog(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 	mustNil(t, c,
 		"EVAL", "redis.log(redis.LOG_NOTICE, 'hello')", "0")
 }
 
 func TestSha1Hex(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	test1 := func(val string, want string) {
 		t.Helper()
@@ -262,10 +243,7 @@ func TestSha1Hex(t *testing.T) {
 }
 
 func TestEvalsha(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	script1sha := "bfbf458525d6a0b19200bfd6db3af481156b367b"
 	mustDo(t, c,
@@ -314,10 +292,7 @@ func TestEvalsha(t *testing.T) {
 }
 
 func TestCmdEvalReply(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	// return nil
 	mustNil(t, c,
@@ -457,10 +432,7 @@ func TestCmdEvalReply(t *testing.T) {
 }
 
 func TestCmdEvalResponse(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustOK(t, c,
 		"EVAL", "return redis.call('set','foo','bar')", "0",
@@ -500,10 +472,7 @@ func TestCmdEvalResponse(t *testing.T) {
 }
 
 func TestCmdEvalAuth(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	eval := "return redis.call('set','foo','bar')"
 
@@ -524,10 +493,7 @@ func TestCmdEvalAuth(t *testing.T) {
 }
 
 func TestLuaReplicate(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustNil(t, c,
 		"EVAL", "redis.replicate_commands()", "0",
@@ -535,10 +501,7 @@ func TestLuaReplicate(t *testing.T) {
 }
 
 func TestLuaTX(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	t.Run("eval", func(t *testing.T) {
 		mustOK(t, c,

--- a/cmd_server_test.go
+++ b/cmd_server_test.go
@@ -9,10 +9,7 @@ import (
 
 // Test DBSIZE, FLUSHDB, and FLUSHALL.
 func TestCmdServer(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Set something
 	{
@@ -104,12 +101,9 @@ func TestCmdServer(t *testing.T) {
 
 // Test TIME
 func TestCmdServerTime(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
-	_, err = c.Do("TIME")
+	_, err := c.Do("TIME")
 	ok(t, err)
 
 	s.SetTime(time.Unix(100, 123456789))
@@ -126,10 +120,7 @@ func TestCmdServerTime(t *testing.T) {
 
 // Test Memory Usage
 func TestCmdServerMemoryUsage(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	c.Do("SET", "foo", "bar")
 	mustDo(t, c,

--- a/cmd_server_test.go
+++ b/cmd_server_test.go
@@ -9,9 +9,7 @@ import (
 
 // Test DBSIZE, FLUSHDB, and FLUSHALL.
 func TestCmdServer(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -106,9 +104,7 @@ func TestCmdServer(t *testing.T) {
 
 // Test TIME
 func TestCmdServerTime(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -130,9 +126,7 @@ func TestCmdServerTime(t *testing.T) {
 
 // Test Memory Usage
 func TestCmdServerMemoryUsage(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_set_test.go
+++ b/cmd_set_test.go
@@ -9,10 +9,7 @@ import (
 
 // Test SADD / SMEMBERS.
 func TestSadd(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		mustDo(t, c,
@@ -101,10 +98,7 @@ func TestSadd(t *testing.T) {
 
 // Test SISMEMBER
 func TestSismember(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.SetAdd("s", "aap", "noot", "mies")
 
@@ -146,10 +140,7 @@ func TestSismember(t *testing.T) {
 
 // Test SMISMEMBER
 func TestSmismember(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.SetAdd("s", "aap", "noot", "mies")
 
@@ -175,10 +166,7 @@ func TestSmismember(t *testing.T) {
 
 // Test SREM
 func TestSrem(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.SetAdd("s", "aap", "noot", "mies", "vuur")
 
@@ -233,10 +221,7 @@ func TestSrem(t *testing.T) {
 
 // Test SMOVE
 func TestSmove(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.SetAdd("s", "aap", "noot")
 
@@ -304,10 +289,7 @@ func TestSmove(t *testing.T) {
 
 // Test SPOP
 func TestSpop(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("basics", func(t *testing.T) {
 		s.SetAdd("s", "aap", "noot")
@@ -366,10 +348,7 @@ func TestSpop(t *testing.T) {
 
 // Test SRANDMEMBER
 func TestSrandmember(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.SetAdd("s", "aap", "noot", "mies")
 
@@ -441,10 +420,7 @@ func TestSrandmember(t *testing.T) {
 
 // Test SDIFF
 func TestSdiff(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.SetAdd("s1", "aap", "noot", "mies")
 	s.SetAdd("s2", "noot", "mies", "vuur")
@@ -497,10 +473,7 @@ func TestSdiff(t *testing.T) {
 
 // Test SDIFFSTORE
 func TestSdiffstore(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.SetAdd("s1", "aap", "noot", "mies")
 	s.SetAdd("s2", "noot", "mies", "vuur")
@@ -535,10 +508,7 @@ func TestSdiffstore(t *testing.T) {
 
 // Test SINTER
 func TestSinter(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.SetAdd("s1", "aap", "noot", "mies")
 	s.SetAdd("s2", "noot", "mies", "vuur")
@@ -599,10 +569,7 @@ func TestSinter(t *testing.T) {
 
 // Test SINTERSTORE
 func TestSinterstore(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.SetAdd("s1", "aap", "noot", "mies")
 	s.SetAdd("s2", "noot", "mies", "vuur")
@@ -646,10 +613,7 @@ func TestSinterstore(t *testing.T) {
 
 // Test SINTERCARD
 func TestSintercard(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	_, _ = s.SetAdd("s1", "a", "b", "c")
 	_, _ = s.SetAdd("s2", "b", "c", "d")
@@ -758,10 +722,7 @@ func TestSintercard(t *testing.T) {
 
 // Test SUNION
 func TestSunion(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.SetAdd("s1", "aap", "noot", "mies")
 	s.SetAdd("s2", "noot", "mies", "vuur")
@@ -820,10 +781,7 @@ func TestSunion(t *testing.T) {
 
 // Test SUNIONSTORE
 func TestSunionstore(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.SetAdd("s1", "aap", "noot", "mies")
 	s.SetAdd("s2", "noot", "mies", "vuur")
@@ -858,10 +816,7 @@ func TestSunionstore(t *testing.T) {
 }
 
 func TestSscan(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// We cheat with sscan. It always returns everything.
 

--- a/cmd_set_test.go
+++ b/cmd_set_test.go
@@ -9,9 +9,7 @@ import (
 
 // Test SADD / SMEMBERS.
 func TestSadd(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -103,9 +101,7 @@ func TestSadd(t *testing.T) {
 
 // Test SISMEMBER
 func TestSismember(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -150,9 +146,7 @@ func TestSismember(t *testing.T) {
 
 // Test SMISMEMBER
 func TestSmismember(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -181,9 +175,7 @@ func TestSmismember(t *testing.T) {
 
 // Test SREM
 func TestSrem(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -241,9 +233,7 @@ func TestSrem(t *testing.T) {
 
 // Test SMOVE
 func TestSmove(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -314,9 +304,7 @@ func TestSmove(t *testing.T) {
 
 // Test SPOP
 func TestSpop(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -378,9 +366,7 @@ func TestSpop(t *testing.T) {
 
 // Test SRANDMEMBER
 func TestSrandmember(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -455,9 +441,7 @@ func TestSrandmember(t *testing.T) {
 
 // Test SDIFF
 func TestSdiff(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -513,9 +497,7 @@ func TestSdiff(t *testing.T) {
 
 // Test SDIFFSTORE
 func TestSdiffstore(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -553,9 +535,7 @@ func TestSdiffstore(t *testing.T) {
 
 // Test SINTER
 func TestSinter(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -619,9 +599,7 @@ func TestSinter(t *testing.T) {
 
 // Test SINTERSTORE
 func TestSinterstore(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -668,9 +646,7 @@ func TestSinterstore(t *testing.T) {
 
 // Test SINTERCARD
 func TestSintercard(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -782,9 +758,7 @@ func TestSintercard(t *testing.T) {
 
 // Test SUNION
 func TestSunion(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -846,9 +820,7 @@ func TestSunion(t *testing.T) {
 
 // Test SUNIONSTORE
 func TestSunionstore(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -886,9 +858,7 @@ func TestSunionstore(t *testing.T) {
 }
 
 func TestSscan(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_sorted_set_test.go
+++ b/cmd_sorted_set_test.go
@@ -9,9 +9,7 @@ import (
 
 // Test ZADD / ZCARD / ZRANK / ZREVRANK.
 func TestSortedSet(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -157,9 +155,7 @@ func TestSortedSet(t *testing.T) {
 
 // Test ZADD
 func TestSortedSetAdd(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -302,9 +298,7 @@ func TestSortedSetAdd(t *testing.T) {
 }
 
 func TestSortedSetRange(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -420,9 +414,7 @@ func TestSortedSetRange(t *testing.T) {
 
 // Test ZREVRANGE
 func TestSortedSetRevRange(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -505,9 +497,7 @@ func TestSortedSetRevRange(t *testing.T) {
 
 // Test ZRANGEBYSCORE,  ZREVRANGEBYSCORE, and ZCOUNT
 func TestSortedSetRangeByScore(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -722,9 +712,7 @@ func TestSortedSetRangeByScore(t *testing.T) {
 }
 
 func TestIssue10(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -744,9 +732,7 @@ func TestIssue10(t *testing.T) {
 
 // Test ZREM
 func TestSortedSetRem(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -808,9 +794,7 @@ func TestSortedSetRem(t *testing.T) {
 
 // Test ZREMRANGEBYLEX
 func TestSortedSetRemRangeByLex(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -887,9 +871,7 @@ func TestSortedSetRemRangeByLex(t *testing.T) {
 
 // Test ZREMRANGEBYRANK
 func TestSortedSetRemRangeByRank(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -971,9 +953,7 @@ func TestSortedSetRemRangeByRank(t *testing.T) {
 
 // Test ZREMRANGEBYSCORE
 func TestSortedSetRangeRemByScore(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1058,9 +1038,7 @@ func TestSortedSetRangeRemByScore(t *testing.T) {
 
 // Test ZSCORE
 func TestSortedSetScore(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1124,9 +1102,7 @@ func TestSortedSetScore(t *testing.T) {
 
 // Test ZMSCORE
 func TestSortedSetMultiScore(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1197,9 +1173,7 @@ func TestSortedSetMultiScore(t *testing.T) {
 
 // Test ZRANGEBYLEX, ZREVRANGEBYLEX, ZLEXCOUNT
 func TestSortedSetRangeByLex(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1423,9 +1397,7 @@ func TestSortedSetRangeByLex(t *testing.T) {
 
 // Test ZINCRBY
 func TestSortedSetIncrby(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1478,9 +1450,7 @@ func TestSortedSetIncrby(t *testing.T) {
 }
 
 func TestZscan(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1634,9 +1604,7 @@ func TestZscan(t *testing.T) {
 }
 
 func TestZunionstore(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1769,9 +1737,7 @@ func TestZunionstore(t *testing.T) {
 }
 
 func TestZunion(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1866,9 +1832,7 @@ func TestZunion(t *testing.T) {
 }
 
 func TestZinter(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1896,9 +1860,7 @@ func TestZinter(t *testing.T) {
 }
 
 func TestZinterstore(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -2106,9 +2068,7 @@ func TestSSRange(t *testing.T) {
 
 // Test ZPOPMIN
 func TestSortedSetPopMin(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -2171,9 +2131,7 @@ func TestSortedSetPopMin(t *testing.T) {
 
 // Test ZPOPMAX
 func TestSortedSetPopMax(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -2238,9 +2196,7 @@ func TestSortedSetPopMax(t *testing.T) {
 
 // Test ZRANDMEMBER
 func TestSortedSetRandmember(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_sorted_set_test.go
+++ b/cmd_sorted_set_test.go
@@ -9,10 +9,7 @@ import (
 
 // Test ZADD / ZCARD / ZRANK / ZREVRANK.
 func TestSortedSet(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		mustDo(t, c,
@@ -155,10 +152,7 @@ func TestSortedSet(t *testing.T) {
 
 // Test ZADD
 func TestSortedSetAdd(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		mustDo(t, c,
@@ -243,7 +237,7 @@ func TestSortedSetAdd(t *testing.T) {
 		// Wrong type of key
 		mustOK(t, c, "SET", "str", "value")
 
-		_, err = s.ZAdd("str", 1.0, "hi")
+		_, err := s.ZAdd("str", 1.0, "hi")
 		mustFail(t, err, msgWrongType)
 
 		mustDo(t, c,
@@ -298,10 +292,7 @@ func TestSortedSetAdd(t *testing.T) {
 }
 
 func TestSortedSetRange(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", 1, "one")
 	s.ZAdd("z", 2, "two")
@@ -414,10 +405,7 @@ func TestSortedSetRange(t *testing.T) {
 
 // Test ZREVRANGE
 func TestSortedSetRevRange(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", 1, "one")
 	s.ZAdd("z", 2, "two")
@@ -497,10 +485,7 @@ func TestSortedSetRevRange(t *testing.T) {
 
 // Test ZRANGEBYSCORE,  ZREVRANGEBYSCORE, and ZCOUNT
 func TestSortedSetRangeByScore(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", -273.15, "zero kelvin")
 	s.ZAdd("z", -4, "minusfour")
@@ -712,10 +697,7 @@ func TestSortedSetRangeByScore(t *testing.T) {
 }
 
 func TestIssue10(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("key", 3.3, "element")
 
@@ -732,10 +714,7 @@ func TestIssue10(t *testing.T) {
 
 // Test ZREM
 func TestSortedSetRem(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", 1, "one")
 	s.ZAdd("z", 2, "two")
@@ -794,10 +773,7 @@ func TestSortedSetRem(t *testing.T) {
 
 // Test ZREMRANGEBYLEX
 func TestSortedSetRemRangeByLex(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", 12, "zero kelvin")
 	s.ZAdd("z", 12, "minusfour")
@@ -871,10 +847,7 @@ func TestSortedSetRemRangeByLex(t *testing.T) {
 
 // Test ZREMRANGEBYRANK
 func TestSortedSetRemRangeByRank(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", 1, "one")
 	s.ZAdd("z", 2, "two")
@@ -953,10 +926,7 @@ func TestSortedSetRemRangeByRank(t *testing.T) {
 
 // Test ZREMRANGEBYSCORE
 func TestSortedSetRangeRemByScore(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", -273.15, "zero kelvin")
 	s.ZAdd("z", -4, "minusfour")
@@ -1038,10 +1008,7 @@ func TestSortedSetRangeRemByScore(t *testing.T) {
 
 // Test ZSCORE
 func TestSortedSetScore(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", 1, "one")
 	s.ZAdd("z", 2, "two")
@@ -1102,10 +1069,7 @@ func TestSortedSetScore(t *testing.T) {
 
 // Test ZMSCORE
 func TestSortedSetMultiScore(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", 1, "one")
 	s.ZAdd("z", 2, "two")
@@ -1173,10 +1137,7 @@ func TestSortedSetMultiScore(t *testing.T) {
 
 // Test ZRANGEBYLEX, ZREVRANGEBYLEX, ZLEXCOUNT
 func TestSortedSetRangeByLex(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", 12, "zero kelvin")
 	s.ZAdd("z", 12, "minusfour")
@@ -1397,10 +1358,7 @@ func TestSortedSetRangeByLex(t *testing.T) {
 
 // Test ZINCRBY
 func TestSortedSetIncrby(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Normal cases
 	{
@@ -1450,10 +1408,7 @@ func TestSortedSetIncrby(t *testing.T) {
 }
 
 func TestZscan(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// We cheat with zscan. It always returns everything.
 
@@ -1604,10 +1559,7 @@ func TestZscan(t *testing.T) {
 }
 
 func TestZunionstore(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("h1", 1.0, "field1")
 	s.ZAdd("h1", 2.0, "field2")
@@ -1737,10 +1689,7 @@ func TestZunionstore(t *testing.T) {
 }
 
 func TestZunion(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("h1", 1.0, "field1")
 	s.ZAdd("h1", 2.0, "field2")
@@ -1832,10 +1781,7 @@ func TestZunion(t *testing.T) {
 }
 
 func TestZinter(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("h1", 1.0, "field1")
 	s.ZAdd("h1", 2.0, "field2")
@@ -1860,10 +1806,7 @@ func TestZinter(t *testing.T) {
 }
 
 func TestZinterstore(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("h1", 1.0, "field1")
 	s.ZAdd("h1", 2.0, "field2")
@@ -2068,10 +2011,7 @@ func TestSSRange(t *testing.T) {
 
 // Test ZPOPMIN
 func TestSortedSetPopMin(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", 1, "one")
 	s.ZAdd("z", 2, "two")
@@ -2131,10 +2071,7 @@ func TestSortedSetPopMin(t *testing.T) {
 
 // Test ZPOPMAX
 func TestSortedSetPopMax(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", 1, "one")
 	s.ZAdd("z", 2, "two")
@@ -2196,10 +2133,7 @@ func TestSortedSetPopMax(t *testing.T) {
 
 // Test ZRANDMEMBER
 func TestSortedSetRandmember(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.ZAdd("z", 1, "one")
 	s.ZAdd("z", 2, "two")

--- a/cmd_stream_test.go
+++ b/cmd_stream_test.go
@@ -15,10 +15,7 @@ import (
 
 // Test XADD / XLEN / XRANGE
 func TestStream(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	mustDo(t, c,
 		"XADD", "s", "1234567-89", "one", "1", "two", "2",
@@ -83,10 +80,7 @@ func TestStream(t *testing.T) {
 
 // Test XADD
 func TestStreamAdd(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("XADD", func(t *testing.T) {
 		mustDo(t, c,
@@ -198,7 +192,7 @@ func TestStreamAdd(t *testing.T) {
 		mustOK(t, c,
 			"SET", "str", "value",
 		)
-		_, err = s.XAdd("str", "*", []string{"hi", "1"})
+		_, err := s.XAdd("str", "*", []string{"hi", "1"})
 		mustFail(t, err, msgWrongType)
 		mustDo(t, c,
 			"XADD", "str", "*", "hi", "1",
@@ -251,12 +245,9 @@ func TestStreamAdd(t *testing.T) {
 
 // Test XLEN
 func TestStreamLen(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
-	_, err = c.Do("XADD", "s", "*", "one", "1", "two", "2")
+	_, err := c.Do("XADD", "s", "*", "one", "1", "two", "2")
 	ok(t, err)
 	_, err = c.Do("XADD", "s", "*", "one", "11", "two", "22")
 	ok(t, err)
@@ -290,12 +281,9 @@ func TestStreamLen(t *testing.T) {
 
 // Test XRANGE / XREVRANGE
 func TestStreamRange(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
-	_, err = c.Do("XADD", "planets", "0-1", "name", "Mercury", "greek-god", "Hermes", "idx", "1")
+	_, err := c.Do("XADD", "planets", "0-1", "name", "Mercury", "greek-god", "Hermes", "idx", "1")
 	ok(t, err)
 	_, err = c.Do("XADD", "planets", "1-0", "name", "Venus", "greek-god", "Aphrodite", "idx", "2")
 	ok(t, err)
@@ -394,12 +382,9 @@ func TestStreamRange(t *testing.T) {
 
 // Test XREAD
 func TestStreamRead(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
-	_, err = c.Do("XADD", "planets", "0-1", "name", "Mercury", "greek-god", "Hermes", "idx", "1")
+	_, err := c.Do("XADD", "planets", "0-1", "name", "Mercury", "greek-god", "Hermes", "idx", "1")
 	ok(t, err)
 	_, err = c.Do("XADD", "planets", "1-0", "name", "Venus", "greek-god", "Aphrodite", "idx", "2")
 	ok(t, err)
@@ -532,10 +517,7 @@ func TestStreamRead(t *testing.T) {
 
 // Test XINFO
 func TestStreamInfo(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"XINFO", "STREAM", "planets",
@@ -577,10 +559,7 @@ func TestStreamInfo(t *testing.T) {
 
 // Test XGROUP
 func TestStreamGroup(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"XGROUP", "CREATE", "s", "processing", "$",
@@ -710,10 +689,7 @@ func TestStreamGroup(t *testing.T) {
 
 // Test XREADGROUP
 func TestStreamReadGroup(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustDo(t, c,
 		"XREADGROUP", "GROUP", "processing", "alice", "STREAMS", "planets", ">",
@@ -804,10 +780,7 @@ func TestStreamReadGroup(t *testing.T) {
 
 // Test XDEL
 func TestStreamDelete(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustOK(t, c,
 		"XGROUP", "CREATE", "planets", "processing", "$", "MKSTREAM",
@@ -859,10 +832,7 @@ func TestStreamDelete(t *testing.T) {
 
 // Test XACK
 func TestStreamAck(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	mustOK(t, c,
 		"XGROUP", "CREATE", "planets", "processing", "$", "MKSTREAM",
@@ -926,10 +896,7 @@ func TestStreamAck(t *testing.T) {
 
 // Test XPENDING
 func TestStreamXpending(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 	now := time.Now()
 	s.SetTime(now)
 
@@ -1068,10 +1035,7 @@ func TestStreamXpending(t *testing.T) {
 
 // Test XTRIM
 func TestStreamTrim(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	t.Run("error cases", func(t *testing.T) {
 		mustDo(t, c,
@@ -1085,7 +1049,7 @@ func TestStreamTrim(t *testing.T) {
 			proto.Error(msgXtrimInvalidMaxLen))
 	})
 
-	_, err = c.Do("XADD", "planets", "0-1", "name", "Mercury")
+	_, err := c.Do("XADD", "planets", "0-1", "name", "Mercury")
 	ok(t, err)
 	_, err = c.Do("XADD", "planets", "1-0", "name", "Venus")
 	ok(t, err)
@@ -1130,10 +1094,7 @@ func TestStreamTrim(t *testing.T) {
 }
 
 func TestStreamAutoClaim(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	now := time.Now()
 	s.SetTime(now)
@@ -1385,10 +1346,7 @@ func TestStreamAutoClaim(t *testing.T) {
 }
 
 func TestStreamClaim(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	now := time.Now()
 	s.SetTime(now)

--- a/cmd_stream_test.go
+++ b/cmd_stream_test.go
@@ -15,9 +15,7 @@ import (
 
 // Test XADD / XLEN / XRANGE
 func TestStream(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -85,9 +83,7 @@ func TestStream(t *testing.T) {
 
 // Test XADD
 func TestStreamAdd(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -255,9 +251,7 @@ func TestStreamAdd(t *testing.T) {
 
 // Test XLEN
 func TestStreamLen(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -296,9 +290,7 @@ func TestStreamLen(t *testing.T) {
 
 // Test XRANGE / XREVRANGE
 func TestStreamRange(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -402,9 +394,7 @@ func TestStreamRange(t *testing.T) {
 
 // Test XREAD
 func TestStreamRead(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -542,9 +532,7 @@ func TestStreamRead(t *testing.T) {
 
 // Test XINFO
 func TestStreamInfo(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -589,9 +577,7 @@ func TestStreamInfo(t *testing.T) {
 
 // Test XGROUP
 func TestStreamGroup(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -724,9 +710,7 @@ func TestStreamGroup(t *testing.T) {
 
 // Test XREADGROUP
 func TestStreamReadGroup(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -820,9 +804,7 @@ func TestStreamReadGroup(t *testing.T) {
 
 // Test XDEL
 func TestStreamDelete(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -877,9 +859,7 @@ func TestStreamDelete(t *testing.T) {
 
 // Test XACK
 func TestStreamAck(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -946,9 +926,7 @@ func TestStreamAck(t *testing.T) {
 
 // Test XPENDING
 func TestStreamXpending(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1090,9 +1068,7 @@ func TestStreamXpending(t *testing.T) {
 
 // Test XTRIM
 func TestStreamTrim(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1154,9 +1130,7 @@ func TestStreamTrim(t *testing.T) {
 }
 
 func TestStreamAutoClaim(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1411,9 +1385,7 @@ func TestStreamAutoClaim(t *testing.T) {
 }
 
 func TestStreamClaim(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_string_test.go
+++ b/cmd_string_test.go
@@ -10,9 +10,7 @@ import (
 
 // Test simple GET/SET keys
 func TestString(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -65,9 +63,7 @@ func TestString(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -210,9 +206,7 @@ func TestSet(t *testing.T) {
 }
 
 func TestMget(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -238,9 +232,7 @@ func TestMget(t *testing.T) {
 }
 
 func TestMset(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -284,9 +276,7 @@ func TestMset(t *testing.T) {
 }
 
 func TestSetex(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -335,9 +325,7 @@ func TestSetex(t *testing.T) {
 }
 
 func TestPsetex(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -386,9 +374,7 @@ func TestPsetex(t *testing.T) {
 }
 
 func TestSetnx(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -424,9 +410,7 @@ func TestSetnx(t *testing.T) {
 }
 
 func TestIncr(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -502,9 +486,7 @@ func TestIncr(t *testing.T) {
 }
 
 func TestIncrBy(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -580,9 +562,7 @@ func TestIncrBy(t *testing.T) {
 }
 
 func TestIncrbyfloat(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -657,9 +637,7 @@ func TestIncrbyfloat(t *testing.T) {
 }
 
 func TestDecrBy(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -735,9 +713,7 @@ func TestDecrBy(t *testing.T) {
 }
 
 func TestDecr(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -809,9 +785,7 @@ func TestDecr(t *testing.T) {
 }
 
 func TestGetex(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -889,9 +863,7 @@ func TestGetex(t *testing.T) {
 }
 
 func TestGetSet(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -949,9 +921,7 @@ func TestGetSet(t *testing.T) {
 }
 
 func TestGetdel(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -994,9 +964,7 @@ func TestGetdel(t *testing.T) {
 }
 
 func TestStrlen(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1040,9 +1008,7 @@ func TestStrlen(t *testing.T) {
 }
 
 func TestAppend(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1089,9 +1055,7 @@ func TestAppend(t *testing.T) {
 }
 
 func TestGetrange(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1159,9 +1123,7 @@ func TestGetrange(t *testing.T) {
 }
 
 func TestSetrange(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1223,9 +1185,7 @@ func TestSetrange(t *testing.T) {
 }
 
 func TestBitcount(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1297,9 +1257,7 @@ func TestBitcount(t *testing.T) {
 }
 
 func TestBitop(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1410,9 +1368,7 @@ func TestBitop(t *testing.T) {
 }
 
 func TestBitpos(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1589,9 +1545,7 @@ func TestBitpos(t *testing.T) {
 }
 
 func TestGetbit(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1646,9 +1600,7 @@ func TestGetbit(t *testing.T) {
 }
 
 func TestSetbit(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -1726,9 +1678,7 @@ func TestSetbit(t *testing.T) {
 }
 
 func TestMsetnx(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/cmd_string_test.go
+++ b/cmd_string_test.go
@@ -10,10 +10,7 @@ import (
 
 // Test simple GET/SET keys
 func TestString(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// SET command
 	mustOK(t, c,
@@ -63,10 +60,7 @@ func TestString(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("basic", func(t *testing.T) {
 		// Simple case
@@ -206,10 +200,7 @@ func TestSet(t *testing.T) {
 }
 
 func TestMget(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Set("zus", "jet")
 	s.Set("teun", "vuur")
@@ -232,10 +223,7 @@ func TestMget(t *testing.T) {
 }
 
 func TestMset(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		mustOK(t, c,
@@ -276,10 +264,7 @@ func TestMset(t *testing.T) {
 }
 
 func TestSetex(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Usual case
 	{
@@ -325,10 +310,7 @@ func TestSetex(t *testing.T) {
 }
 
 func TestPsetex(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Usual case
 	{
@@ -374,10 +356,7 @@ func TestPsetex(t *testing.T) {
 }
 
 func TestSetnx(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Existing key
 	{
@@ -403,17 +382,14 @@ func TestSetnx(t *testing.T) {
 			"SETNX", "foo", "not bar",
 		)
 		equals(t, "hash", s.Type("foo"))
-		_, err = s.Get("foo")
+		_, err := s.Get("foo")
 		equals(t, ErrWrongType, err)
 		equals(t, "baz", s.HGet("foo", "bar"))
 	}
 }
 
 func TestIncr(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Existing key
 	{
@@ -486,10 +462,7 @@ func TestIncr(t *testing.T) {
 }
 
 func TestIncrBy(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Existing key
 	{
@@ -562,10 +535,7 @@ func TestIncrBy(t *testing.T) {
 }
 
 func TestIncrbyfloat(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Existing key
 	{
@@ -637,10 +607,7 @@ func TestIncrbyfloat(t *testing.T) {
 }
 
 func TestDecrBy(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Existing key
 	{
@@ -713,10 +680,7 @@ func TestDecrBy(t *testing.T) {
 }
 
 func TestDecr(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Existing key
 	{
@@ -785,10 +749,7 @@ func TestDecr(t *testing.T) {
 }
 
 func TestGetex(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("basic", func(t *testing.T) {
 		// Missing key
@@ -863,10 +824,7 @@ func TestGetex(t *testing.T) {
 }
 
 func TestGetSet(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Existing key
 	{
@@ -921,10 +879,7 @@ func TestGetSet(t *testing.T) {
 }
 
 func TestGetdel(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Missing key
 	{
@@ -964,10 +919,7 @@ func TestGetdel(t *testing.T) {
 }
 
 func TestStrlen(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Existing key
 	{
@@ -1008,10 +960,7 @@ func TestStrlen(t *testing.T) {
 }
 
 func TestAppend(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Existing key
 	{
@@ -1055,10 +1004,7 @@ func TestAppend(t *testing.T) {
 }
 
 func TestGetrange(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		s.Set("foo", "abcdefg")
@@ -1123,10 +1069,7 @@ func TestGetrange(t *testing.T) {
 }
 
 func TestSetrange(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	// Simple case
 	{
@@ -1185,10 +1128,7 @@ func TestSetrange(t *testing.T) {
 }
 
 func TestBitcount(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		s.Set("countme", "a") // 'a' is 0x1100001
@@ -1257,10 +1197,7 @@ func TestBitcount(t *testing.T) {
 }
 
 func TestBitop(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		and := func(a, b byte) byte { return a & b }
@@ -1368,10 +1305,7 @@ func TestBitop(t *testing.T) {
 }
 
 func TestBitpos(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	t.Run("basic", func(t *testing.T) {
 		s.Set("findme", "\xff\xf0\x00")
@@ -1545,10 +1479,7 @@ func TestBitpos(t *testing.T) {
 }
 
 func TestGetbit(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		s.Set("findme", "\x08")
@@ -1600,10 +1531,7 @@ func TestGetbit(t *testing.T) {
 }
 
 func TestSetbit(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		s.Set("findme", "\x08")
@@ -1678,10 +1606,7 @@ func TestSetbit(t *testing.T) {
 }
 
 func TestMsetnx(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	{
 		must1(t, c,

--- a/cmd_transactions_test.go
+++ b/cmd_transactions_test.go
@@ -7,10 +7,7 @@ import (
 )
 
 func TestMulti(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	// Do accept MULTI, but use it as a no-op
 	mustOK(t, c,
@@ -19,10 +16,7 @@ func TestMulti(t *testing.T) {
 }
 
 func TestExec(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	// Exec without MULTI.
 	mustDo(t, c,
@@ -32,10 +26,7 @@ func TestExec(t *testing.T) {
 }
 
 func TestDiscard(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	// DISCARD without MULTI.
 	mustDo(t, c,
@@ -45,10 +36,7 @@ func TestDiscard(t *testing.T) {
 }
 
 func TestWatch(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	_, c := runWithClient(t)
 
 	// Simple WATCH
 	mustOK(t, c,
@@ -69,10 +57,7 @@ func TestWatch(t *testing.T) {
 
 // Test simple multi/exec block.
 func TestSimpleTransaction(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	mustOK(t, c,
 		"MULTI",
@@ -98,10 +83,7 @@ func TestSimpleTransaction(t *testing.T) {
 }
 
 func TestDiscardTransaction(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Set("aap", "noot")
 
@@ -126,10 +108,7 @@ func TestDiscardTransaction(t *testing.T) {
 }
 
 func TestTxQueueErr(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	mustOK(t, c,
 		"MULTI",
@@ -163,10 +142,7 @@ func TestTxQueueErr(t *testing.T) {
 
 func TestTxWatch(t *testing.T) {
 	// Watch with no error.
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 
 	s.Set("one", "two")
 	mustOK(t, c,
@@ -190,10 +166,7 @@ func TestTxWatch(t *testing.T) {
 
 func TestTxWatchErr(t *testing.T) {
 	// Watch with en error.
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 	c2, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c2.Close()
@@ -228,10 +201,7 @@ func TestTxWatchErr(t *testing.T) {
 }
 
 func TestUnwatch(t *testing.T) {
-	s := RunT(t)
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 	c2, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c2.Close()

--- a/cmd_transactions_test.go
+++ b/cmd_transactions_test.go
@@ -7,9 +7,7 @@ import (
 )
 
 func TestMulti(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -21,9 +19,7 @@ func TestMulti(t *testing.T) {
 }
 
 func TestExec(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -36,9 +32,7 @@ func TestExec(t *testing.T) {
 }
 
 func TestDiscard(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -51,9 +45,7 @@ func TestDiscard(t *testing.T) {
 }
 
 func TestWatch(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -77,9 +69,7 @@ func TestWatch(t *testing.T) {
 
 // Test simple multi/exec block.
 func TestSimpleTransaction(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -108,9 +98,7 @@ func TestSimpleTransaction(t *testing.T) {
 }
 
 func TestDiscardTransaction(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -138,9 +126,7 @@ func TestDiscardTransaction(t *testing.T) {
 }
 
 func TestTxQueueErr(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -177,9 +163,7 @@ func TestTxQueueErr(t *testing.T) {
 
 func TestTxWatch(t *testing.T) {
 	// Watch with no error.
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -206,9 +190,7 @@ func TestTxWatch(t *testing.T) {
 
 func TestTxWatchErr(t *testing.T) {
 	// Watch with en error.
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()
@@ -246,9 +228,7 @@ func TestTxWatchErr(t *testing.T) {
 }
 
 func TestUnwatch(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
 	defer c.Close()

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -13,9 +13,7 @@ import (
 
 // Test starting/stopping a server
 func TestServer(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 
 	c, err := proto.Dial(s.Addr())
 	ok(t, err)
@@ -31,10 +29,8 @@ func TestServer(t *testing.T) {
 }
 
 func TestMultipleServers(t *testing.T) {
-	s1, err := Run()
-	ok(t, err)
-	s2, err := Run()
-	ok(t, err)
+	s1 := RunT(t)
+	s2 := RunT(t)
 	if s1.Addr() == s2.Addr() {
 		t.Fatal("Non-unique addresses", s1.Addr(), s2.Addr())
 	}
@@ -48,14 +44,13 @@ func TestMultipleServers(t *testing.T) {
 }
 
 func TestRestart(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
+	s := RunT(t)
 	addr := s.Addr()
 
 	s.Set("color", "red")
 
 	s.Close()
-	err = s.Restart()
+	err := s.Restart()
 	ok(t, err)
 	if have, want := s.Addr(), addr; have != want {
 		t.Fatalf("have: %s, want: %s", have, want)
@@ -86,8 +81,7 @@ func TestAddr(t *testing.T) {
 }
 
 func TestDump(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
+	s := RunT(t)
 	s.Set("aap", "noot")
 	s.Set("vuur", "mies")
 	s.HSet("ahash", "aap", "noot")
@@ -129,8 +123,7 @@ func TestDump(t *testing.T) {
 }
 
 func TestDumpList(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
+	s := RunT(t)
 	s.Push("elements", "earth")
 	s.Push("elements", "wind")
 	s.Push("elements", "fire")
@@ -144,8 +137,7 @@ func TestDumpList(t *testing.T) {
 }
 
 func TestDumpSet(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
+	s := RunT(t)
 	s.SetAdd("elements", "earth")
 	s.SetAdd("elements", "wind")
 	s.SetAdd("elements", "fire")
@@ -159,8 +151,7 @@ func TestDumpSet(t *testing.T) {
 }
 
 func TestDumpSortedSet(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
+	s := RunT(t)
 	s.ZAdd("elements", 2.0, "wind")
 	s.ZAdd("elements", 3.0, "earth")
 	s.ZAdd("elements", 1.0, "fire")
@@ -174,8 +165,7 @@ func TestDumpSortedSet(t *testing.T) {
 }
 
 func TestDumpStream(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
+	s := RunT(t)
 	s.XAdd("elements", "0-1", []string{"name", "earth"})
 	s.XAdd("elements", "123456789-0", []string{"name", "wind"})
 	s.XAdd("elements", "123456789-1", []string{"name", "fire"})
@@ -200,8 +190,7 @@ func TestDumpStream(t *testing.T) {
 }
 
 func TestKeysAndFlush(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
+	s := RunT(t)
 	s.Set("aap", "noot")
 	s.Set("vuur", "mies")
 	s.Set("muur", "oom")
@@ -226,8 +215,7 @@ func TestKeysAndFlush(t *testing.T) {
 }
 
 func TestExpireWithFastForward(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
+	s := RunT(t)
 
 	s.Set("aap", "noot")
 	s.Set("noot", "aap")

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -13,11 +13,7 @@ import (
 
 // Test starting/stopping a server
 func TestServer(t *testing.T) {
-	s := RunT(t)
-
-	c, err := proto.Dial(s.Addr())
-	ok(t, err)
-	defer c.Close()
+	s, c := runWithClient(t)
 	mustDo(t, c, "PING", proto.Inline("PONG"))
 
 	// A single client

--- a/redis_test.go
+++ b/redis_test.go
@@ -9,9 +9,7 @@ import (
 )
 
 func TestRedis(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
+	s := RunT(t)
 
 	peer := &server.Peer{}
 	var wg sync.WaitGroup

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -228,6 +228,7 @@ func TestTLS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer c.Close()
 	res, err := c.Do("PING")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Thanks for great project, here is a little cleanup - because less is more :sparkles: :sparkles: :sparkles: 

<hr />

**Change Run() to RunT(t) in tests**

[Goleak](http://go.uber.org/goleak) found unclosed goroutines in tests, for example
`miniredis_test.go:TestDump` never calls `s.Close()`  
https://github.com/alicebob/miniredis/blob/9ac631e686635ffc17cb1fb45027b8a67f125c80/miniredis_test.go#L88-L129

I've changed `Run()` calls to `RunT(t)` calls to:
 - ensure all goroutines all closed after test is finished
 - we have shorter tests (no need to check for error and close server

There is no risk in using RunT even if test manually closes server
because calling Close multiple times is not an issue.

<hr />

**Move create of client in tests to helper function**

Removed duplicated code in tests using helper function.
