### PR TITLE
Ignore 'redis.set_repl()' call

### DIFF
--- a/cmd_scripting_test.go
+++ b/cmd_scripting_test.go
@@ -495,9 +495,17 @@ func TestCmdEvalAuth(t *testing.T) {
 func TestLuaReplicate(t *testing.T) {
 	_, c := runWithClient(t)
 
-	mustNil(t, c,
-		"EVAL", "redis.replicate_commands()", "0",
-	)
+	t.Run("replicate_commands", func(t *testing.T) {
+		mustNil(t, c,
+			"EVAL", "redis.replicate_commands()", "0",
+		)
+	})
+
+	t.Run("set_repl", func(t *testing.T) {
+		mustNil(t, c,
+			"EVAL", "redis.set_repl(redis.REPL_NONE)", "0",
+		)
+	})
 }
 
 func TestLuaTX(t *testing.T) {

--- a/integration/script_test.go
+++ b/integration/script_test.go
@@ -416,6 +416,12 @@ func TestScriptReplicate(t *testing.T) {
 			"EVAL", `redis.replicate_commands();`, "0",
 		)
 	})
+
+	testRaw(t, func(c *client) {
+		c.Do(
+			"EVAL", `redis.set_repl(redis.REPL_NONE);`, "0",
+		)
+	})
 }
 
 func TestScriptTx(t *testing.T) {

--- a/lua.go
+++ b/lua.go
@@ -161,6 +161,15 @@ func mkLua(srv *server.Server, c *server.Peer, sha string) (map[string]lua.LGFun
 			// ignored
 			return 1
 		},
+		"set_repl": func(l *lua.LState) int {
+			top := l.GetTop()
+			if top != 1 {
+				l.Error(lua.LString("wrong number of arguments"), 1)
+				return 0
+			}
+			// ignored
+			return 1
+		},
 	}, luaRedisConstants
 }
 


### PR DESCRIPTION
Fixing: https://github.com/alicebob/miniredis/issues/367

Follow the pattern for how we handled `redis.replicate_commands()`

Doc: https://redis.io/docs/interact/programmability/lua-api/