### PR TITLE
Fix makefile help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,26 @@
-.PHONY: test testrace int ci clean help
+.PHONY: test
 test: ### Run unit tests
 	go test ./...
 
+.PHONY: testrace
 testrace: ### Run unit tests with race detector
 	go test -race ./...
 
+.PHONY: int
 int: ### Run integration tests (doesn't download redis server)
 	${MAKE} -C integration int
 
+.PHONY: ci
 ci: ### Run full tests suite (including download and compilation of proper redis server)
 	${MAKE} test
 	${MAKE} -C integration redis_src/redis-server int
 	${MAKE} testrace
 
+.PHONY: clean
 clean: ### Clean integration test files and remove compiled redis from integration/redis_src
 	${MAKE} -C integration clean
 
+.PHONY: help
 help:
 ifeq ($(UNAME), Linux)
 	@grep -P '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 .PHONY: test testrace int ci clean help
-test:
+test: ### Run unit tests
 	go test ./...
 
-testrace:
+testrace: ### Run unit tests with race detector
 	go test -race ./...
 
-int:
+int: ### Run integration tests (doesn't download redis server)
 	${MAKE} -C integration int
 
-ci:
+ci: ### Run full tests suite (including download and compilation of proper redis server)
 	${MAKE} test
 	${MAKE} -C integration redis_src/redis-server int
 	${MAKE} testrace
 
-clean:
+clean: ### Clean integration test files and remove compiled redis from integration/redis_src
 	${MAKE} -C integration clean
 
 help:


### PR DESCRIPTION
**Add Makefile help comments**

[Commit](https://github.com/alicebob/miniredis/commit/72133e9456e2f740e23b764c9ae4e252b9bd6c82) that originally introduced make help target also had special comments (starting with `###`) for help target to parse.  
Makefile that was finally merged after some changes lacked this comments. Without this comments when executed help prints empty output.

<hr />

**Move .PHONY next to each target**


It's clearer to keep target and it's .PHONY together. When reading Makefile it's easier to see if target is phony or not (without jumping back to first line and reading all of .PHONY dependencies). It's also harder to forget remove/rename .PHONY dependency when target is changed when they are together.

There is no official standard but [make documentation](https://www.gnu.org/software/make/manual/html_node/Special-Variables.html) in .DEFAULT_GOAL use multiple .PHONY:
```makefile
.PHONY: foo
foo: ; @echo $@

$(warning default goal is $(.DEFAULT_GOAL))

# Reset the default goal.
.DEFAULT_GOAL :=

.PHONY: bar
bar: ; @echo $@
```