### PR TITLE
Add github action cache for redis-server binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,5 +16,28 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go }}
+
+    - name: Cache redis server binary restore
+      id: cache-redis-server-binary-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: integration/redis_src/redis-server
+        key: "redis-server-binary-${{ hashFiles('integration/get_redis.sh') }}"
+
+    - name: Prevent redis binary rebuild
+      if: steps.cache-redis-server-binary-restore.outputs.cache-hit
+      run: "touch -m integration/redis_src/redis-server"
+      # Make uses modification timestamp to decide if redis-server needs to be rebuilt.
+      # In github actions get_redis.sh has modification time set when cloned but redis-server binary has modification
+      # time when it was cached (always older than clone). By updating timestamp we avoid unnecessary build.
+      # Cache key includes get_redis.sh file hash so there is no risk of using stale binary.
+
     - name: Test
       run: make ci
+
+    - name: Cache redis server binary save
+      if: steps.cache-redis-server-binary-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: integration/redis_src/redis-server
+        key: ${{ steps.cache-redis-server-binary-restore.outputs.cache-primary-key }}


### PR DESCRIPTION
`${MAKE} -C integration redis_src/redis-server` that is part of `ci` target takes around 2 minutes to execute. With addition of cache preventing rebuild of `redis-server` tests run time drops from ~2m50s to ~50s.

Currently github actions are [free for public repositories](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration) but I think that shorter execution time will improve developer experience :)

Due to matrix build for go versions, when redis is upgraded, build will be run multiple times in parallel. Unnecessary parallel builds can be avoided but since we don't upgrade redis too often I feel it would be unnecessary complication.

Perhaps even better solution might be usage of [testcontainers](https://golang.testcontainers.org/). Integration tests would basically download and run official redis docker image and spin it up for tests. There would be no need for cache or building binary but docker dependency would be introduced. I have decided to introduce cache because docker dependency has pros and cons that need to be discussed while cache is clear and easy win ;)