### PR TITLE
upgrade to actions/setup-go v5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Go ${{ matrix.go }}
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 


### PR DESCRIPTION
Fixes some warnings in the actions thing. It's all one big pile of JS, isn't it?