### PR TITLE
Support for the NOMKSTREAM option for XADD

### DIFF
--- a/cmd_stream.go
+++ b/cmd_stream.go
@@ -50,6 +50,11 @@ func (m *Miniredis) cmdXadd(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		maxlen := -1
 		minID := ""
+		makeStream := true
+		if strings.ToLower(args[0]) == "nomkstream" {
+			args = args[1:]
+			makeStream = false
+		}
 		if strings.ToLower(args[0]) == "maxlen" {
 			args = args[1:]
 			// we don't treat "~" special
@@ -101,7 +106,10 @@ func (m *Miniredis) cmdXadd(c *server.Peer, cmd string, args []string) {
 			return
 		}
 		if s == nil {
-			// TODO: NOMKSTREAM
+			if !makeStream {
+				c.WriteNull()
+				return
+			}
 			s, _ = db.newStream(key)
 		}
 

--- a/cmd_stream_test.go
+++ b/cmd_stream_test.go
@@ -189,7 +189,19 @@ func TestStreamAdd(t *testing.T) {
 
 	t.Run("XADD NOMKSTREAM", func(t *testing.T) {
 		mustDo(t, c,
+			"XADD", "reallynosuchkey", "NOMKSTREAM", "*", "one", "1",
+			proto.Nil,
+		)
+		mustDo(t, c,
+			"XADD", "reallynosuchkey", "NOMKSTREAM", "MINID", "1672545848004-0", "*", "one", "1",
+			proto.Nil,
+		)
+		mustDo(t, c,
 			"XADD", "reallynosuchkey", "NOMKSTREAM", "MAXLEN", "~", "10", "*", "one", "1",
+			proto.Nil,
+		)
+		mustDo(t, c,
+			"XADD", "reallynosuchkey", "NOMKSTREAM", "MAXLEN", "~", "10", "MINID", "1672545848004-0", "*", "one", "1",
 			proto.Nil,
 		)
 	})

--- a/cmd_stream_test.go
+++ b/cmd_stream_test.go
@@ -200,10 +200,6 @@ func TestStreamAdd(t *testing.T) {
 			"XADD", "reallynosuchkey", "NOMKSTREAM", "MAXLEN", "~", "10", "*", "one", "1",
 			proto.Nil,
 		)
-		mustDo(t, c,
-			"XADD", "reallynosuchkey", "NOMKSTREAM", "MAXLEN", "~", "10", "MINID", "1672545848004-0", "*", "one", "1",
-			proto.Nil,
-		)
 	})
 
 	t.Run("error cases", func(t *testing.T) {

--- a/cmd_stream_test.go
+++ b/cmd_stream_test.go
@@ -187,6 +187,13 @@ func TestStreamAdd(t *testing.T) {
 		)
 	})
 
+	t.Run("XADD NOMKSTREAM", func(t *testing.T) {
+		mustDo(t, c,
+			"XADD", "reallynosuchkey", "NOMKSTREAM", "MAXLEN", "~", "10", "*", "one", "1",
+			proto.Nil,
+		)
+	})
+
 	t.Run("error cases", func(t *testing.T) {
 		// Wrong type of key
 		mustOK(t, c,

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -25,6 +25,11 @@ func TestStream(t *testing.T) {
 				"18446744073709551000-0",
 				"name", "Earth",
 			)
+			c.Do("XADD",
+				"reallynosuchkey",
+				"*",
+				"name", "Earth",
+			)
 			c.Error("ID specified", "XADD",
 				"planets",
 				"18446744073709551000-0", // <-- duplicate
@@ -124,6 +129,10 @@ func TestStream(t *testing.T) {
 
 			c.Do("MULTI")
 			c.Do("XADD", "planets", "MAXLEN", "four", "*", "name", "Mercury")
+			c.Do("EXEC")
+
+			c.Do("MULTI")
+			c.Do("XADD", "reallynosuchkey", "MAXLEN", "four", "*", "name", "Mercury")
 			c.Do("EXEC")
 		})
 	})

--- a/integration/stream_test.go
+++ b/integration/stream_test.go
@@ -27,6 +27,7 @@ func TestStream(t *testing.T) {
 			)
 			c.Do("XADD",
 				"reallynosuchkey",
+				"NOMKSTREAM",
 				"*",
 				"name", "Earth",
 			)
@@ -132,7 +133,7 @@ func TestStream(t *testing.T) {
 			c.Do("EXEC")
 
 			c.Do("MULTI")
-			c.Do("XADD", "reallynosuchkey", "MAXLEN", "four", "*", "name", "Mercury")
+			c.Do("XADD", "reallynosuchkey", "NOMKSTREAM", "MAXLEN", "four", "*", "name", "Mercury")
 			c.Do("EXEC")
 		})
 	})


### PR DESCRIPTION
Hi! First of all, thanks for a very useful library.

This adds support for the `NOMKSTREAM` option for `XADD` as specified by https://redis.io/docs/latest/commands/xadd/

`XADD key [NOMKSTREAM] [<MAXLEN | MINID> [= | ~] threshold  [LIMIT count]] <* | id> field value [field value ...]`

What the option does:

> If the key does not exist, as a side effect of running this command the key is created with a stream value. *The creation of stream's key can be disabled with the NOMKSTREAM option.*

And the response when the option is provided:

> [Nil reply](https://redis.io/docs/latest/develop/reference/protocol-spec#bulk-strings): if the NOMKSTREAM option is given and the key doesn't exist.