### PR TITLE
Return empty array for SRANDMEMBER on nonexistent key

### DIFF
--- a/cmd_set.go
+++ b/cmd_set.go
@@ -582,6 +582,10 @@ func (m *Miniredis) cmdSrandmember(c *server.Peer, cmd string, args []string) {
 		db := m.db(ctx.selectedDB)
 
 		if !db.exists(key) {
+			if withCount {
+				c.WriteLen(0)
+				return
+			}
 			c.WriteNull()
 			return
 		}

--- a/cmd_set_test.go
+++ b/cmd_set_test.go
@@ -381,6 +381,12 @@ func TestSrandmember(t *testing.T) {
 		"SRANDMEMBER", "nosuch",
 	)
 
+	// a nonexisting key with count
+	mustDo(t, c,
+		"SRANDMEMBER", "nosuch", "1",
+		proto.Strings(),
+	)
+
 	t.Run("errors", func(t *testing.T) {
 		s.SetAdd("chk", "aap", "noot")
 		s.Set("str", "value")

--- a/integration/set_test.go
+++ b/integration/set_test.go
@@ -191,7 +191,8 @@ func TestSetSrandmember(t *testing.T) {
 		c.Do("SRANDMEMBER", "s", "-5")
 
 		c.Do("SRANDMEMBER", "s", "0")
-		c.Do("SPOP", "nosuch")
+		c.Do("SRANDMEMBER", "nosuch")
+		c.Do("SRANDMEMBER", "nosuch", "1")
 
 		// failure cases
 		c.Error("wrong number", "SRANDMEMBER")


### PR DESCRIPTION
https://redis.io/docs/latest/commands/srandmember/
SRANDMEMBER with `count` returns an empty array if the key does not exist.
Updated the implementation and added test for this case.