### PR TITLE
Add HEXPIRE support

### DIFF
--- a/cmd_hash_test.go
+++ b/cmd_hash_test.go
@@ -684,3 +684,19 @@ func TestHashRandField(t *testing.T) {
 		proto.Error(msgInvalidInt),
 	)
 }
+
+func TestHashHexpire(t *testing.T) {
+	s, c := runWithClient(t)
+
+	must1(t, c, "HSET", "aap", "noot", "mies")
+	must1(t, c, "HEXPIRE", "aap", "30", "FIELDS", "1", "noot")
+
+	s.FastForward(time.Second * 29)
+	equals(t, time.Second, s.dbs[0].hashTtls["aap"]["noot"])
+
+	s.FastForward(time.Second)
+	_, exists := s.dbs[0].hashTtls["aap"]["noot"]
+	assert(t, !exists, "ttl still exists for field")
+	_, exists = s.dbs[0].hashKeys["aap"]["noot"]
+	assert(t, !exists, "field still exists")
+}

--- a/cmd_hash_test.go
+++ b/cmd_hash_test.go
@@ -776,10 +776,6 @@ func TestHashHexpire(t *testing.T) {
 	must1(t, c, "HEXPIRE", "aap", "30", "FIELDS", "1", "noot4")
 	must0(t, c, "HEXPIRE", "aap", "20", "GT", "FIELDS", "1", "noot4")
 
-	// LT option with no expiration
-	must1(t, c, "HSET", "aap", "noot5", "mies")
-	must0(t, c, "HEXPIRE", "aap", "30", "LT", "FIELDS", "1", "noot5")
-
 	// LT option with expiration greater than current expiration
 	must1(t, c, "HSET", "aap", "noot6", "mies")
 	must1(t, c, "HEXPIRE", "aap", "30", "FIELDS", "1", "noot6")

--- a/direct.go
+++ b/direct.go
@@ -509,6 +509,7 @@ func (db *RedisDB) hdel(k, f string) {
 		return
 	}
 	delete(db.hashKeys[k], f)
+	delete(db.hashTtls[k], f)
 	db.incr(k)
 }
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=
-github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 h1:uvdUDbHQHO85qeSydJtItA4T55Pw6BtAejd0APRJOCE=
 github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/redis.go
+++ b/redis.go
@@ -59,6 +59,11 @@ const (
 	msgMaxLengthIsNegative  = "ERR MAXLEN can't be negative"
 	msgLimitIsNegative      = "ERR LIMIT can't be negative"
 	msgMemorySubcommand     = "ERR unknown subcommand '%s'. Try MEMORY HELP."
+	msgNumFieldIsNegative   = "ERR Parameter `numFields` should be greater than 0"
+	msgNumFieldMismatch     = "ERR The `numfields` parameter must match the number of arguments"
+	msgFieldMissing         = "ERR Mandatory argument FIELDS is missing or not at the right position"
+	msgGTAndLT              = "ERR GT and LT options at the same time are not compatible"
+	msgNXandXXGTLT          = "ERR NX and XX, GT or LT options at the same time are not compatible"
 )
 
 func errWrongNumber(cmd string) string {


### PR DESCRIPTION
Add the [HEXPIRE](https://redis.io/docs/latest/commands/hexpire/) command by tracking ttls for each field in hashTtls.