### PR TITLE
Fix MEMORY subcommand casing

### DIFF
--- a/cmd_server.go
+++ b/cmd_server.go
@@ -38,9 +38,9 @@ func (m *Miniredis) cmdMemory(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		cmd, args := args[0], args[1:]
+		cmd, args := strings.ToLower(args[0]), args[1:]
 		switch cmd {
-		case "USAGE":
+		case "usage":
 			if len(args) < 1 {
 				setDirty(c)
 				c.WriteError(errWrongNumber("memory|usage"))

--- a/cmd_server_test.go
+++ b/cmd_server_test.go
@@ -139,3 +139,13 @@ func TestCmdServerMemoryUsage(t *testing.T) {
 		proto.Int(124), // normally, with Redis it should be 56 but we don't have the same overhead as Redis
 	)
 }
+
+func TestCmdServerMemoryUsageLowerCase(t *testing.T) {
+	_, c := runWithClient(t)
+
+	c.Do("SET", "foo", "bar")
+	mustDo(t, c,
+		"memory", "usage", "foo",
+		proto.Int(19),
+	)
+}


### PR DESCRIPTION
Redis commands should be case insensitive and miniredis respects that, except, it turns out, in the case of `MEMORY USAGE` where it would only recognize the uppercase form. This is especially troublesome when the [official client](https://github.com/redis/go-redis/blob/caa2592db731428e542670e8e6d3ccfa60603e8e/commands.go#L660) uses the lower case form 🙈 