### PR TITLE
redis.setresp({2,3})

### DIFF
--- a/cmd_scripting.go
+++ b/cmd_scripting.go
@@ -101,16 +101,20 @@ func (m *Miniredis) runLuaScript(c *server.Peer, sha, script string, args []stri
 	l.Push(lua.LString("redis"))
 	l.Call(1, 0)
 
+	// lua can call redis.setresp(...), but it's tmp state.
+	oldresp := c.Resp3
 	if err := doScript(l, script); err != nil {
 		c.WriteError(err.Error())
 		return false
 	}
 
 	luaToRedis(l, c, l.Get(1))
+	c.Resp3 = oldresp
+	c.SwitchResp3 = nil
 	return true
 }
 
-// doScript pre-compiiles the given script into a Lua prototype,
+// doScript pre-compiles the given script into a Lua prototype,
 // then executes the pre-compiled function against the given lua state.
 //
 // This is thread-safe.
@@ -259,7 +263,6 @@ func (m *Miniredis) cmdScript(c *server.Peer, cmd string, args []string) {
 			c.WriteError(msgScriptFlush)
 			return
 		}
-
 	default:
 		setDirty(c)
 		c.WriteError(fmt.Sprintf(msgFScriptUsageSimple, strings.ToUpper(opts.subcmd)))
@@ -276,7 +279,6 @@ func (m *Miniredis) cmdScript(c *server.Peer, cmd string, args []string) {
 			sha := sha1Hex(opts.script)
 			m.scripts[sha] = opts.script
 			c.WriteBulk(sha)
-
 		case "exists":
 			c.WriteLen(len(args))
 			for _, arg := range args {
@@ -286,11 +288,9 @@ func (m *Miniredis) cmdScript(c *server.Peer, cmd string, args []string) {
 					c.WriteInt(0)
 				}
 			}
-
 		case "flush":
 			m.scripts = map[string]string{}
 			c.WriteOK()
-
 		}
 	})
 }

--- a/lua.go
+++ b/lua.go
@@ -158,7 +158,8 @@ func mkLua(srv *server.Server, c *server.Peer, sha string) (map[string]lua.LGFun
 			return 1
 		},
 		"replicate_commands": func(l *lua.LState) int {
-			// ignored
+			// always succeeds since 7.0.0
+			l.Push(lua.LTrue)
 			return 1
 		},
 		"set_repl": func(l *lua.LState) int {
@@ -169,6 +170,21 @@ func mkLua(srv *server.Server, c *server.Peer, sha string) (map[string]lua.LGFun
 			}
 			// ignored
 			return 1
+		},
+		"setresp": func(l *lua.LState) int {
+			level := l.CheckInt(1)
+			toresp3 := false
+			switch level {
+			case 2:
+				toresp3 = false
+			case 3:
+				toresp3 = true
+			default:
+				l.Error(lua.LString("RESP version must be 2 or 3"), 1)
+				return 0
+			}
+			c.SwitchResp3 = &toresp3
+			return 0
 		},
 	}, luaRedisConstants
 }
@@ -226,7 +242,7 @@ func luaToRedis(l *lua.LState, c *server.Peer, value lua.LValue) {
 			luaToRedis(l, c, r)
 		}
 	default:
-		panic("....")
+		panic(fmt.Sprintf("wat: %T", t))
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -216,6 +216,10 @@ func (s *Server) Dispatch(c *Peer, args []string) {
 	s.infoCmds++
 	s.mu.Unlock()
 	cb(c, cmdUp, args)
+	if c.SwitchResp3 != nil {
+		c.Resp3 = *c.SwitchResp3
+		c.SwitchResp3 = nil
+	}
 }
 
 // TotalCommands is total (known) commands since this the server started
@@ -245,6 +249,7 @@ type Peer struct {
 	w            *bufio.Writer
 	closed       bool
 	Resp3        bool
+	SwitchResp3  *bool       // we'll switch to this version _after_ the command
 	Ctx          interface{} // anything goes, server won't touch this
 	onDisconnect []func()    // list of callbacks
 	mu           sync.Mutex  // for Block()


### PR DESCRIPTION
Fixes #393

at least when I use this:
```
    luaScript := `redis.setresp(3); return 42`
```
(otherwise the client complains about a nil)