### PR TITLE
Fix XAUTOCLAIM skipping the initial start message.

### DIFF
--- a/cmd_stream.go
+++ b/cmd_stream.go
@@ -1536,7 +1536,7 @@ func xautoclaim(
 		return nextCallId, nil
 	}
 
-	msgs := g.pendingAfter(start)
+	msgs := g.pendingAfterOrEqual(start)
 	var res []StreamEntry
 	for i, p := range msgs {
 		if minIdleTime > 0 && now.Before(p.lastDelivery.Add(minIdleTime)) {

--- a/cmd_stream_test.go
+++ b/cmd_stream_test.go
@@ -1322,6 +1322,21 @@ func TestStreamAutoClaim(t *testing.T) {
 			proto.Array(),
 		),
 	)
+
+	// read again using the ID returned from the last XAUTOCLAIM call as 'start'.
+	// the results include that starting message. unlike XREADGROUP, the results of XAUTOCLAIM
+	// are INCLUSIVE of the start ID.
+	mustDo(t, c,
+		"XAUTOCLAIM", "planets", "processing", "bob", "15000", "0-2", "COUNT", "1",
+		proto.Array(
+			proto.String("0-0"),
+			proto.Array(
+				proto.Array(proto.String("0-2"), proto.Strings("name", "Venus")),
+			),
+			proto.Array(),
+		),
+	)
+
 	mustDo(t, c,
 		"XINFO", "CONSUMERS", "planets", "processing",
 		proto.Array(
@@ -1350,8 +1365,8 @@ func TestStreamAutoClaim(t *testing.T) {
 			proto.Array(
 				proto.String("0-2"),
 				proto.String("bob"),
-				proto.Int(20000),
-				proto.Int(4),
+				proto.Int(0),
+				proto.Int(5),
 			),
 		),
 	)

--- a/stream.go
+++ b/stream.go
@@ -440,6 +440,13 @@ func (s *streamKey) delete(ids []string) (int, error) {
 	return count, nil
 }
 
+func (g *streamGroup) pendingAfterOrEqual(id string) []pendingEntry {
+	pos := sort.Search(len(g.pending), func(i int) bool {
+		return streamCmp(id, g.pending[i].id) <= 0
+	})
+	return g.pending[pos:]
+}
+
 func (g *streamGroup) pendingAfter(id string) []pendingEntry {
 	pos := sort.Search(len(g.pending), func(i int) bool {
 		return streamCmp(id, g.pending[i].id) < 0


### PR DESCRIPTION
According to the official XAUTOCLAIM docs:

```It transfers ownership to <consumer> of messages pending for more than <min-idle-time> milliseconds and having an equal or greater ID than <start>.```

Skipping the 'start' message meant that when using the next-id from a previous call as a cursor to read multiple batches, the first message of each subsequent batch would be skipped. With this fix, all messages will be read. This behavior now matches that of official Redis.