### PR TITLE
Simple support for `DUMP` and `RESTORE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Implemented commands:
  - Key
    - COPY
    - DEL
+   - DUMP -- partly, only handles string keys
    - EXISTS
    - EXPIRE
    - EXPIREAT
@@ -50,6 +51,7 @@ Implemented commands:
    - RANDOMKEY -- see m.Seed(...)
    - RENAME
    - RENAMENX
+   - RESTORE -- partly, only handles string keys
    - SCAN
    - TOUCH
    - TTL
@@ -301,10 +303,8 @@ Commands which will probably not be implemented:
     - ~~READONLY~~
     - ~~READWRITE~~
  - Key
-    - ~~DUMP~~
     - ~~MIGRATE~~
     - ~~OBJECT~~
-    - ~~RESTORE~~
     - ~~WAIT~~
  - Scripting
     - ~~FCALL / FCALL_RO *~~

--- a/cmd_connection.go
+++ b/cmd_connection.go
@@ -213,12 +213,7 @@ func (m *Miniredis) cmdEcho(c *server.Peer, cmd string, args []string) {
 
 // SELECT
 func (m *Miniredis) cmdSelect(c *server.Peer, cmd string, args []string) {
-	if len(args) != 1 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.isValidCMD(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, exactly(1)) {
 		return
 	}
 

--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -104,15 +104,7 @@ func expireParse(cmd string, args []string) (*expireOpts, error) {
 // converted to a duration.
 func makeCmdExpire(m *Miniredis, unix bool, d time.Duration) func(*server.Peer, string, []string) {
 	return func(c *server.Peer, cmd string, args []string) {
-		if len(args) < 2 {
-			setDirty(c)
-			c.WriteError(errWrongNumber(cmd))
-			return
-		}
-		if !m.handleAuth(c) {
-			return
-		}
-		if m.checkPubsub(c, cmd) {
+		if !m.isValidCMD(c, cmd, args, atLeast(2)) {
 			return
 		}
 
@@ -178,16 +170,7 @@ func makeCmdExpire(m *Miniredis, unix bool, d time.Duration) func(*server.Peer, 
 // [pexpiretime]: https://redis.io/commands/pexpiretime/
 func (m *Miniredis) makeCmdExpireTime(timeResultStrategy func(time.Time) int) server.Cmd {
 	return func(c *server.Peer, cmd string, args []string) {
-		if len(args) != 1 {
-			setDirty(c)
-			c.WriteError(errWrongNumber(cmd))
-			return
-		}
-
-		if !m.handleAuth(c) {
-			return
-		}
-		if m.checkPubsub(c, cmd) {
+		if !m.isValidCMD(c, cmd, args, exactly(1)) {
 			return
 		}
 
@@ -213,16 +196,7 @@ func (m *Miniredis) makeCmdExpireTime(timeResultStrategy func(time.Time) int) se
 
 // TOUCH
 func (m *Miniredis) cmdTouch(c *server.Peer, cmd string, args []string) {
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
-		return
-	}
-
-	if len(args) == 0 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
+	if !m.isValidCMD(c, cmd, args, atLeast(1)) {
 		return
 	}
 
@@ -241,15 +215,7 @@ func (m *Miniredis) cmdTouch(c *server.Peer, cmd string, args []string) {
 
 // TTL
 func (m *Miniredis) cmdTTL(c *server.Peer, cmd string, args []string) {
-	if len(args) != 1 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, exactly(1)) {
 		return
 	}
 
@@ -276,15 +242,7 @@ func (m *Miniredis) cmdTTL(c *server.Peer, cmd string, args []string) {
 
 // PTTL
 func (m *Miniredis) cmdPTTL(c *server.Peer, cmd string, args []string) {
-	if len(args) != 1 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, exactly(1)) {
 		return
 	}
 
@@ -311,15 +269,7 @@ func (m *Miniredis) cmdPTTL(c *server.Peer, cmd string, args []string) {
 
 // PERSIST
 func (m *Miniredis) cmdPersist(c *server.Peer, cmd string, args []string) {
-	if len(args) != 1 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, exactly(1)) {
 		return
 	}
 
@@ -347,16 +297,7 @@ func (m *Miniredis) cmdPersist(c *server.Peer, cmd string, args []string) {
 
 // DEL and UNLINK
 func (m *Miniredis) cmdDel(c *server.Peer, cmd string, args []string) {
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
-		return
-	}
-
-	if len(args) == 0 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
+	if !m.isValidCMD(c, cmd, args, atLeast(1)) {
 		return
 	}
 
@@ -376,15 +317,7 @@ func (m *Miniredis) cmdDel(c *server.Peer, cmd string, args []string) {
 
 // TYPE
 func (m *Miniredis) cmdType(c *server.Peer, cmd string, args []string) {
-	if len(args) != 1 {
-		setDirty(c)
-		c.WriteError("usage error")
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, exactly(1)) {
 		return
 	}
 
@@ -405,15 +338,7 @@ func (m *Miniredis) cmdType(c *server.Peer, cmd string, args []string) {
 
 // EXISTS
 func (m *Miniredis) cmdExists(c *server.Peer, cmd string, args []string) {
-	if len(args) < 1 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, atLeast(1)) {
 		return
 	}
 
@@ -432,15 +357,7 @@ func (m *Miniredis) cmdExists(c *server.Peer, cmd string, args []string) {
 
 // MOVE
 func (m *Miniredis) cmdMove(c *server.Peer, cmd string, args []string) {
-	if len(args) != 2 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, exactly(2)) {
 		return
 	}
 
@@ -470,15 +387,7 @@ func (m *Miniredis) cmdMove(c *server.Peer, cmd string, args []string) {
 
 // KEYS
 func (m *Miniredis) cmdKeys(c *server.Peer, cmd string, args []string) {
-	if len(args) != 1 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, exactly(1)) {
 		return
 	}
 
@@ -497,15 +406,7 @@ func (m *Miniredis) cmdKeys(c *server.Peer, cmd string, args []string) {
 
 // RANDOMKEY
 func (m *Miniredis) cmdRandomkey(c *server.Peer, cmd string, args []string) {
-	if len(args) != 0 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, exactly(0)) {
 		return
 	}
 
@@ -529,15 +430,7 @@ func (m *Miniredis) cmdRandomkey(c *server.Peer, cmd string, args []string) {
 
 // RENAME
 func (m *Miniredis) cmdRename(c *server.Peer, cmd string, args []string) {
-	if len(args) != 2 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, exactly(2)) {
 		return
 	}
 
@@ -564,15 +457,7 @@ func (m *Miniredis) cmdRename(c *server.Peer, cmd string, args []string) {
 
 // RENAMENX
 func (m *Miniredis) cmdRenamenx(c *server.Peer, cmd string, args []string) {
-	if len(args) != 2 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, exactly(2)) {
 		return
 	}
 
@@ -658,15 +543,7 @@ func scanParse(cmd string, args []string) (*scanOpts, error) {
 
 // SCAN
 func (m *Miniredis) cmdScan(c *server.Peer, cmd string, args []string) {
-	if len(args) < 1 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, atLeast(1)) {
 		return
 	}
 
@@ -766,15 +643,7 @@ func copyParse(cmd string, args []string) (*copyOpts, error) {
 
 // COPY
 func (m *Miniredis) cmdCopy(c *server.Peer, cmd string, args []string) {
-	if len(args) < 2 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
-		return
-	}
-	if !m.handleAuth(c) {
-		return
-	}
-	if m.checkPubsub(c, cmd) {
+	if !m.isValidCMD(c, cmd, args, atLeast(2)) {
 		return
 	}
 

--- a/cmd_generic_test.go
+++ b/cmd_generic_test.go
@@ -287,7 +287,7 @@ func TestUnlink(t *testing.T) {
 	})
 }
 
-func TestDump(t *testing.T) {
+func TestDumpCommand(t *testing.T) {
 	s, c := runWithClient(t)
 	s.Set("existing-key", "value")
 	s.HSet("set-key", "a", "b")

--- a/cmd_geo.go
+++ b/cmd_geo.go
@@ -40,7 +40,7 @@ func (m *Miniredis) cmdGeoadd(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if db.exists(key) && db.t(key) != "zset" {
+		if db.exists(key) && db.t(key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -103,7 +103,7 @@ func (m *Miniredis) cmdGeodist(c *server.Peer, cmd string, args []string) {
 			c.WriteNull()
 			return
 		}
-		if db.t(key) != "zset" {
+		if db.t(key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -157,7 +157,7 @@ func (m *Miniredis) cmdGeopos(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if db.exists(key) && db.t(key) != "zset" {
+		if db.exists(key) && db.t(key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -495,7 +495,7 @@ func (m *Miniredis) cmdGeoradiusbymember(c *server.Peer, cmd string, args []stri
 			return
 		}
 
-		if db.t(opts.key) != "zset" {
+		if db.t(opts.key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}

--- a/cmd_hash.go
+++ b/cmd_hash.go
@@ -54,7 +54,7 @@ func (m *Miniredis) cmdHset(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
-		if t, ok := db.keys[key]; ok && t != "hash" {
+		if t, ok := db.keys[key]; ok && t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -91,14 +91,14 @@ func (m *Miniredis) cmdHsetnx(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[opts.key]; ok && t != "hash" {
+		if t, ok := db.keys[opts.key]; ok && t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
 
 		if _, ok := db.hashKeys[opts.key]; !ok {
 			db.hashKeys[opts.key] = map[string]string{}
-			db.keys[opts.key] = "hash"
+			db.keys[opts.key] = keyTypeHash
 		}
 		_, ok := db.hashKeys[opts.key][opts.field]
 		if ok {
@@ -135,7 +135,7 @@ func (m *Miniredis) cmdHmset(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[key]; ok && t != "hash" {
+		if t, ok := db.keys[key]; ok && t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -173,7 +173,7 @@ func (m *Miniredis) cmdHget(c *server.Peer, cmd string, args []string) {
 			c.WriteNull()
 			return
 		}
-		if t != "hash" {
+		if t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -217,7 +217,7 @@ func (m *Miniredis) cmdHdel(c *server.Peer, cmd string, args []string) {
 			c.WriteInt(0)
 			return
 		}
-		if t != "hash" {
+		if t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -270,7 +270,7 @@ func (m *Miniredis) cmdHexists(c *server.Peer, cmd string, args []string) {
 			c.WriteInt(0)
 			return
 		}
-		if t != "hash" {
+		if t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -307,7 +307,7 @@ func (m *Miniredis) cmdHgetall(c *server.Peer, cmd string, args []string) {
 			c.WriteMapLen(0)
 			return
 		}
-		if t != "hash" {
+		if t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -343,7 +343,7 @@ func (m *Miniredis) cmdHkeys(c *server.Peer, cmd string, args []string) {
 			c.WriteLen(0)
 			return
 		}
-		if db.t(key) != "hash" {
+		if db.t(key) != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -380,7 +380,7 @@ func (m *Miniredis) cmdHstrlen(c *server.Peer, cmd string, args []string) {
 			c.WriteInt(0)
 			return
 		}
-		if t != "hash" {
+		if t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -414,7 +414,7 @@ func (m *Miniredis) cmdHvals(c *server.Peer, cmd string, args []string) {
 			c.WriteLen(0)
 			return
 		}
-		if t != "hash" {
+		if t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -451,7 +451,7 @@ func (m *Miniredis) cmdHlen(c *server.Peer, cmd string, args []string) {
 			c.WriteInt(0)
 			return
 		}
-		if t != "hash" {
+		if t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -479,7 +479,7 @@ func (m *Miniredis) cmdHmget(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[key]; ok && t != "hash" {
+		if t, ok := db.keys[key]; ok && t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -530,7 +530,7 @@ func (m *Miniredis) cmdHincrby(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[opts.key]; ok && t != "hash" {
+		if t, ok := db.keys[opts.key]; ok && t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -577,7 +577,7 @@ func (m *Miniredis) cmdHincrbyfloat(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[opts.key]; ok && t != "hash" {
+		if t, ok := db.keys[opts.key]; ok && t != keyTypeHash {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -662,7 +662,7 @@ func (m *Miniredis) cmdHscan(c *server.Peer, cmd string, args []string) {
 			c.WriteLen(0)    // no elements
 			return
 		}
-		if db.exists(opts.key) && db.t(opts.key) != "hash" {
+		if db.exists(opts.key) && db.t(opts.key) != keyTypeHash {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}

--- a/cmd_hll.go
+++ b/cmd_hll.go
@@ -28,7 +28,7 @@ func (m *Miniredis) cmdPfadd(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if db.exists(key) && db.t(key) != "hll" {
+		if db.exists(key) && db.t(key) != keyTypeHll {
 			c.WriteError(ErrNotValidHllValue.Error())
 			return
 		}

--- a/cmd_info.go
+++ b/cmd_info.go
@@ -8,13 +8,7 @@ import (
 
 // Command 'INFO' from https://redis.io/commands/info/
 func (m *Miniredis) cmdInfo(c *server.Peer, cmd string, args []string) {
-	if !m.isValidCMD(c, cmd) {
-		return
-	}
-
-	if len(args) > 1 {
-		setDirty(c)
-		c.WriteError(errWrongNumber(cmd))
+	if !m.isValidCMD(c, cmd, args, between(0, 1)) {
 		return
 	}
 

--- a/cmd_list.go
+++ b/cmd_list.go
@@ -84,7 +84,7 @@ func (m *Miniredis) cmdBXpop(c *server.Peer, cmd string, args []string, lr leftr
 				if !db.exists(key) {
 					continue
 				}
-				if db.t(key) != "list" {
+				if db.t(key) != keyTypeList {
 					c.WriteError(msgWrongType)
 					return true
 				}
@@ -145,7 +145,7 @@ func (m *Miniredis) cmdLindex(c *server.Peer, cmd string, args []string) {
 			c.WriteNull()
 			return
 		}
-		if t != "list" {
+		if t != keyTypeList {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -239,7 +239,7 @@ func (m *Miniredis) cmdLpos(c *server.Peer, cmd string, args []string) {
 			c.WriteNull()
 			return
 		}
-		if t != "list" {
+		if t != keyTypeList {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -347,7 +347,7 @@ func (m *Miniredis) cmdLinsert(c *server.Peer, cmd string, args []string) {
 			c.WriteInt(0)
 			return
 		}
-		if t != "list" {
+		if t != keyTypeList {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -401,7 +401,7 @@ func (m *Miniredis) cmdLlen(c *server.Peer, cmd string, args []string) {
 			c.WriteInt(0)
 			return
 		}
-		if t != "list" {
+		if t != keyTypeList {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -471,7 +471,7 @@ func (m *Miniredis) cmdXpop(c *server.Peer, cmd string, args []string, lr leftri
 			c.WriteNull()
 			return
 		}
-		if db.t(opts.key) != "list" {
+		if db.t(opts.key) != keyTypeList {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -530,7 +530,7 @@ func (m *Miniredis) cmdXpush(c *server.Peer, cmd string, args []string, lr leftr
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if db.exists(key) && db.t(key) != "list" {
+		if db.exists(key) && db.t(key) != keyTypeList {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -580,7 +580,7 @@ func (m *Miniredis) cmdXpushx(c *server.Peer, cmd string, args []string, lr left
 			c.WriteInt(0)
 			return
 		}
-		if db.t(key) != "list" {
+		if db.t(key) != keyTypeList {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -629,7 +629,7 @@ func (m *Miniredis) cmdLrange(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[opts.key]; ok && t != "list" {
+		if t, ok := db.keys[opts.key]; ok && t != keyTypeList {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -680,7 +680,7 @@ func (m *Miniredis) cmdLrem(c *server.Peer, cmd string, args []string) {
 			c.WriteInt(0)
 			return
 		}
-		if db.t(opts.key) != "list" {
+		if db.t(opts.key) != keyTypeList {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -754,7 +754,7 @@ func (m *Miniredis) cmdLset(c *server.Peer, cmd string, args []string) {
 			c.WriteError(msgKeyNotFound)
 			return
 		}
-		if db.t(opts.key) != "list" {
+		if db.t(opts.key) != keyTypeList {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -811,7 +811,7 @@ func (m *Miniredis) cmdLtrim(c *server.Peer, cmd string, args []string) {
 			c.WriteOK()
 			return
 		}
-		if t != "list" {
+		if t != keyTypeList {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -852,7 +852,7 @@ func (m *Miniredis) cmdRpoplpush(c *server.Peer, cmd string, args []string) {
 			c.WriteNull()
 			return
 		}
-		if db.t(src) != "list" || (db.exists(dst) && db.t(dst) != "list") {
+		if db.t(src) != keyTypeList || (db.exists(dst) && db.t(dst) != keyTypeList) {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -897,7 +897,7 @@ func (m *Miniredis) cmdBrpoplpush(c *server.Peer, cmd string, args []string) {
 			if !db.exists(opts.src) {
 				return false
 			}
-			if db.t(opts.src) != "list" || (db.exists(opts.dst) && db.t(opts.dst) != "list") {
+			if db.t(opts.src) != keyTypeList || (db.exists(opts.dst) && db.t(opts.dst) != keyTypeList) {
 				c.WriteError(msgWrongType)
 				return true
 			}
@@ -949,7 +949,7 @@ func (m *Miniredis) cmdLmove(c *server.Peer, cmd string, args []string) {
 			c.WriteNull()
 			return
 		}
-		if db.t(opts.src) != "list" || (db.exists(opts.dst) && db.t(opts.dst) != "list") {
+		if db.t(opts.src) != keyTypeList || (db.exists(opts.dst) && db.t(opts.dst) != keyTypeList) {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -1017,7 +1017,7 @@ func (m *Miniredis) cmdBlmove(c *server.Peer, cmd string, args []string) {
 			if !db.exists(opts.src) {
 				return false
 			}
-			if db.t(opts.src) != "list" || (db.exists(opts.dst) && db.t(opts.dst) != "list") {
+			if db.t(opts.src) != keyTypeList || (db.exists(opts.dst) && db.t(opts.dst) != keyTypeList) {
 				c.WriteError(msgWrongType)
 				return true
 			}

--- a/cmd_server.go
+++ b/cmd_server.go
@@ -57,19 +57,19 @@ func (m *Miniredis) cmdMemory(c *server.Peer, cmd string, args []string) {
 				ok    bool
 			)
 			switch db.keys[args[0]] {
-			case "string":
+			case keyTypeString:
 				value, ok = db.stringKeys[args[0]]
-			case "set":
+			case keyTypeSet:
 				value, ok = db.setKeys[args[0]]
-			case "hash":
+			case keyTypeHash:
 				value, ok = db.hashKeys[args[0]]
-			case "list":
+			case keyTypeList:
 				value, ok = db.listKeys[args[0]]
-			case "hll":
+			case keyTypeHll:
 				value, ok = db.hllKeys[args[0]]
-			case "zset":
+			case keyTypeSortedSet:
 				value, ok = db.sortedsetKeys[args[0]]
-			case "stream":
+			case keyTypeStream:
 				value, ok = db.streamKeys[args[0]]
 			}
 			if !ok {

--- a/cmd_set.go
+++ b/cmd_set.go
@@ -50,7 +50,7 @@ func (m *Miniredis) cmdSadd(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if db.exists(key) && db.t(key) != "set" {
+		if db.exists(key) && db.t(key) != keyTypeSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}

--- a/cmd_sorted_set.go
+++ b/cmd_sorted_set.go
@@ -142,7 +142,7 @@ outer:
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if db.exists(opts.key) && db.t(opts.key) != "zset" {
+		if db.exists(opts.key) && db.t(opts.key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -216,7 +216,7 @@ func (m *Miniredis) cmdZcard(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
-		if db.t(key) != "zset" {
+		if db.t(key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -272,7 +272,7 @@ func (m *Miniredis) cmdZcount(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
-		if db.t(opts.key) != "zset" {
+		if db.t(opts.key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -316,7 +316,7 @@ func (m *Miniredis) cmdZincrby(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if db.exists(opts.key) && db.t(opts.key) != "zset" {
+		if db.exists(opts.key) && db.t(opts.key) != keyTypeSortedSet {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -445,12 +445,12 @@ func (m *Miniredis) makeCmdZinter(store bool) func(c *server.Peer, cmd string, a
 
 				var set map[string]float64
 				switch db.t(key) {
-				case "set":
+				case keyTypeSet:
 					set = map[string]float64{}
 					for elem := range db.setKeys[key] {
 						set[elem] = 1.0
 					}
-				case "zset":
+				case keyTypeSortedSet:
 					set = db.sortedSet(key)
 				default:
 					c.WriteError(msgWrongType)
@@ -550,7 +550,7 @@ func (m *Miniredis) cmdZlexcount(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
-		if db.t(opts.Key) != "zset" {
+		if db.t(opts.Key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -846,7 +846,7 @@ func (m *Miniredis) makeCmdZrank(reverse bool) server.Cmd {
 				return
 			}
 
-			if db.t(key) != "zset" {
+			if db.t(key) != keyTypeSortedSet {
 				c.WriteError(ErrWrongType.Error())
 				return
 			}
@@ -900,7 +900,7 @@ func (m *Miniredis) cmdZrem(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
-		if db.t(key) != "zset" {
+		if db.t(key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -954,7 +954,7 @@ func (m *Miniredis) cmdZremrangebylex(c *server.Peer, cmd string, args []string)
 			return
 		}
 
-		if db.t(opts.Key) != "zset" {
+		if db.t(opts.Key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -1007,7 +1007,7 @@ func (m *Miniredis) cmdZremrangebyrank(c *server.Peer, cmd string, args []string
 			return
 		}
 
-		if db.t(opts.key) != "zset" {
+		if db.t(opts.key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -1067,7 +1067,7 @@ func (m *Miniredis) cmdZremrangebyscore(c *server.Peer, cmd string, args []strin
 			return
 		}
 
-		if db.t(opts.key) != "zset" {
+		if db.t(opts.key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -1106,7 +1106,7 @@ func (m *Miniredis) cmdZscore(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
-		if db.t(key) != "zset" {
+		if db.t(key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -1147,7 +1147,7 @@ func (m *Miniredis) cmdZMscore(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
-		if db.t(key) != "zset" {
+		if db.t(key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -1466,12 +1466,12 @@ func executeZUnion(db *RedisDB, opts zunionOptions) (sortedSet, error) {
 
 		var set map[string]float64
 		switch db.t(key) {
-		case "set":
+		case keyTypeSet:
 			set = map[string]float64{}
 			for elem := range db.setKeys[key] {
 				set[elem] = 1.0
 			}
-		case "zset":
+		case keyTypeSortedSet:
 			set = db.sortedSet(key)
 		default:
 			return nil, errors.New(msgWrongType)
@@ -1574,7 +1574,7 @@ func (m *Miniredis) cmdZscan(c *server.Peer, cmd string, args []string) {
 
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
-		if db.exists(opts.key) && db.t(opts.key) != "zset" {
+		if db.exists(opts.key) && db.t(opts.key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -1652,7 +1652,7 @@ func (m *Miniredis) cmdZpopmax(reverse bool) server.Cmd {
 				return
 			}
 
-			if db.t(key) != "zset" {
+			if db.t(key) != keyTypeSortedSet {
 				c.WriteError(ErrWrongType.Error())
 				return
 			}
@@ -1734,7 +1734,7 @@ func (m *Miniredis) cmdZrandmember(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
-		if db.t(opts.key) != "zset" {
+		if db.t(opts.key) != keyTypeSortedSet {
 			c.WriteError(ErrWrongType.Error())
 			return
 		}
@@ -1801,7 +1801,7 @@ func runRange(m *Miniredis, c *server.Peer, cctx *connCtx, opts optsRange) {
 		return
 	}
 
-	if db.t(opts.Key) != "zset" {
+	if db.t(opts.Key) != keyTypeSortedSet {
 		c.WriteError(ErrWrongType.Error())
 		return
 	}
@@ -1864,7 +1864,7 @@ func runRangeByScore(m *Miniredis, c *server.Peer, cctx *connCtx, opts optsRange
 		return
 	}
 
-	if db.t(opts.Key) != "zset" {
+	if db.t(opts.Key) != keyTypeSortedSet {
 		c.WriteError(ErrWrongType.Error())
 		return
 	}
@@ -1951,7 +1951,7 @@ func runRangeByLex(m *Miniredis, c *server.Peer, cctx *connCtx, opts optsRangeBy
 		return
 	}
 
-	if db.t(opts.Key) != "zset" {
+	if db.t(opts.Key) != keyTypeSortedSet {
 		c.WriteError(ErrWrongType.Error())
 		return
 	}

--- a/cmd_stream.go
+++ b/cmd_stream.go
@@ -252,7 +252,7 @@ func (m *Miniredis) makeCmdXrange(reverse bool) server.Cmd {
 				return
 			}
 
-			if db.t(opts.key) != "stream" {
+			if db.t(opts.key) != keyTypeStream {
 				c.WriteError(ErrWrongType.Error())
 				return
 			}

--- a/cmd_string.go
+++ b/cmd_string.go
@@ -160,7 +160,7 @@ func (m *Miniredis) cmdSet(c *server.Peer, cmd string, args []string) {
 			}
 		}
 		if opts.get {
-			if t, ok := db.keys[opts.key]; ok && t != "string" {
+			if t, ok := db.keys[opts.key]; ok && t != keyTypeString {
 				c.WriteError(msgWrongType)
 				return
 			}
@@ -403,7 +403,7 @@ func (m *Miniredis) cmdGet(c *server.Peer, cmd string, args []string) {
 			c.WriteNull()
 			return
 		}
-		if db.t(key) != "string" {
+		if db.t(key) != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -490,7 +490,7 @@ func (m *Miniredis) cmdGetex(c *server.Peer, cmd string, args []string) {
 			db.ttl[opts.key] = opts.ttl
 		}
 
-		if db.t(opts.key) != "string" {
+		if db.t(opts.key) != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -518,7 +518,7 @@ func (m *Miniredis) cmdGetset(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[key]; ok && t != "string" {
+		if t, ok := db.keys[key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -560,7 +560,7 @@ func (m *Miniredis) cmdGetdel(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
-		if db.t(key) != "string" {
+		if db.t(key) != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -590,7 +590,7 @@ func (m *Miniredis) cmdMget(c *server.Peer, cmd string, args []string) {
 
 		c.WriteLen(len(args))
 		for _, k := range args {
-			if t, ok := db.keys[k]; !ok || t != "string" {
+			if t, ok := db.keys[k]; !ok || t != keyTypeString {
 				c.WriteNull()
 				continue
 			}
@@ -623,7 +623,7 @@ func (m *Miniredis) cmdIncr(c *server.Peer, cmd string, args []string) {
 		db := m.db(ctx.selectedDB)
 
 		key := args[0]
-		if t, ok := db.keys[key]; ok && t != "string" {
+		if t, ok := db.keys[key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -663,7 +663,7 @@ func (m *Miniredis) cmdIncrby(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[opts.key]; ok && t != "string" {
+		if t, ok := db.keys[opts.key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -703,7 +703,7 @@ func (m *Miniredis) cmdIncrbyfloat(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[key]; ok && t != "string" {
+		if t, ok := db.keys[key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -736,7 +736,7 @@ func (m *Miniredis) cmdDecr(c *server.Peer, cmd string, args []string) {
 		db := m.db(ctx.selectedDB)
 
 		key := args[0]
-		if t, ok := db.keys[key]; ok && t != "string" {
+		if t, ok := db.keys[key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -776,7 +776,7 @@ func (m *Miniredis) cmdDecrby(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[opts.key]; ok && t != "string" {
+		if t, ok := db.keys[opts.key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -810,7 +810,7 @@ func (m *Miniredis) cmdStrlen(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[key]; ok && t != "string" {
+		if t, ok := db.keys[key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -838,7 +838,7 @@ func (m *Miniredis) cmdAppend(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[key]; ok && t != "string" {
+		if t, ok := db.keys[key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -880,7 +880,7 @@ func (m *Miniredis) cmdGetrange(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[opts.key]; ok && t != "string" {
+		if t, ok := db.keys[opts.key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -923,7 +923,7 @@ func (m *Miniredis) cmdSetrange(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[opts.key]; ok && t != "string" {
+		if t, ok := db.keys[opts.key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -980,7 +980,7 @@ func (m *Miniredis) cmdBitcount(c *server.Peer, cmd string, args []string) {
 			c.WriteInt(0)
 			return
 		}
-		if db.t(opts.key) != "string" {
+		if db.t(opts.key) != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -1030,13 +1030,13 @@ func (m *Miniredis) cmdBitop(c *server.Peer, cmd string, args []string) {
 		switch opts.op {
 		case "AND", "OR", "XOR":
 			first := opts.input[0]
-			if t, ok := db.keys[first]; ok && t != "string" {
+			if t, ok := db.keys[first]; ok && t != keyTypeString {
 				c.WriteError(msgWrongType)
 				return
 			}
 			res := []byte(db.stringKeys[first])
 			for _, vk := range opts.input[1:] {
-				if t, ok := db.keys[vk]; ok && t != "string" {
+				if t, ok := db.keys[vk]; ok && t != keyTypeString {
 					c.WriteError(msgWrongType)
 					return
 				}
@@ -1062,7 +1062,7 @@ func (m *Miniredis) cmdBitop(c *server.Peer, cmd string, args []string) {
 				return
 			}
 			key := opts.input[0]
-			if t, ok := db.keys[key]; ok && t != "string" {
+			if t, ok := db.keys[key]; ok && t != keyTypeString {
 				c.WriteError(msgWrongType)
 				return
 			}
@@ -1124,7 +1124,7 @@ func (m *Miniredis) cmdBitpos(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[opts.Key]; ok && t != "string" {
+		if t, ok := db.keys[opts.Key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		} else if !ok {
@@ -1215,7 +1215,7 @@ func (m *Miniredis) cmdGetbit(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[opts.key]; ok && t != "string" {
+		if t, ok := db.keys[opts.key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}
@@ -1276,7 +1276,7 @@ func (m *Miniredis) cmdSetbit(c *server.Peer, cmd string, args []string) {
 	withTx(m, c, func(c *server.Peer, ctx *connCtx) {
 		db := m.db(ctx.selectedDB)
 
-		if t, ok := db.keys[opts.key]; ok && t != "string" {
+		if t, ok := db.keys[opts.key]; ok && t != keyTypeString {
 			c.WriteError(msgWrongType)
 			return
 		}

--- a/direct.go
+++ b/direct.go
@@ -90,7 +90,7 @@ func (db *RedisDB) Get(k string) (string, error) {
 	if !db.exists(k) {
 		return "", ErrKeyNotFound
 	}
-	if db.t(k) != "string" {
+	if db.t(k) != keyTypeString {
 		return "", ErrWrongType
 	}
 	return db.stringGet(k), nil
@@ -108,7 +108,7 @@ func (db *RedisDB) Set(k, v string) error {
 	defer db.master.Unlock()
 	defer db.master.signal.Broadcast()
 
-	if db.exists(k) && db.t(k) != "string" {
+	if db.exists(k) && db.t(k) != keyTypeString {
 		return ErrWrongType
 	}
 	db.del(k, true) // Remove expire
@@ -127,7 +127,7 @@ func (db *RedisDB) Incr(k string, delta int) (int, error) {
 	defer db.master.Unlock()
 	defer db.master.signal.Broadcast()
 
-	if db.exists(k) && db.t(k) != "string" {
+	if db.exists(k) && db.t(k) != keyTypeString {
 		return 0, ErrWrongType
 	}
 
@@ -151,7 +151,7 @@ func (db *RedisDB) Incrfloat(k string, delta float64) (float64, error) {
 	defer db.master.Unlock()
 	defer db.master.signal.Broadcast()
 
-	if db.exists(k) && db.t(k) != "string" {
+	if db.exists(k) && db.t(k) != keyTypeString {
 		return 0, ErrWrongType
 	}
 
@@ -180,7 +180,7 @@ func (db *RedisDB) List(k string) ([]string, error) {
 	if !db.exists(k) {
 		return nil, ErrKeyNotFound
 	}
-	if db.t(k) != "list" {
+	if db.t(k) != keyTypeList {
 		return nil, ErrWrongType
 	}
 	return db.listKeys[k], nil
@@ -197,7 +197,7 @@ func (db *RedisDB) Lpush(k, v string) (int, error) {
 	defer db.master.Unlock()
 	defer db.master.signal.Broadcast()
 
-	if db.exists(k) && db.t(k) != "list" {
+	if db.exists(k) && db.t(k) != keyTypeList {
 		return 0, ErrWrongType
 	}
 	return db.listLpush(k, v), nil
@@ -217,7 +217,7 @@ func (db *RedisDB) Lpop(k string) (string, error) {
 	if !db.exists(k) {
 		return "", ErrKeyNotFound
 	}
-	if db.t(k) != "list" {
+	if db.t(k) != keyTypeList {
 		return "", ErrWrongType
 	}
 	return db.listLpop(k), nil
@@ -240,7 +240,7 @@ func (db *RedisDB) Push(k string, v ...string) (int, error) {
 	defer db.master.Unlock()
 	defer db.master.signal.Broadcast()
 
-	if db.exists(k) && db.t(k) != "list" {
+	if db.exists(k) && db.t(k) != keyTypeList {
 		return 0, ErrWrongType
 	}
 	return db.listPush(k, v...), nil
@@ -265,7 +265,7 @@ func (db *RedisDB) Pop(k string) (string, error) {
 	if !db.exists(k) {
 		return "", ErrKeyNotFound
 	}
-	if db.t(k) != "list" {
+	if db.t(k) != keyTypeList {
 		return "", ErrWrongType
 	}
 
@@ -289,7 +289,7 @@ func (db *RedisDB) SetAdd(k string, elems ...string) (int, error) {
 	defer db.master.Unlock()
 	defer db.master.signal.Broadcast()
 
-	if db.exists(k) && db.t(k) != "set" {
+	if db.exists(k) && db.t(k) != keyTypeSet {
 		return 0, ErrWrongType
 	}
 	return db.setAdd(k, elems...), nil
@@ -314,7 +314,7 @@ func (db *RedisDB) Members(k string) ([]string, error) {
 	if !db.exists(k) {
 		return nil, ErrKeyNotFound
 	}
-	if db.t(k) != "set" {
+	if db.t(k) != keyTypeSet {
 		return nil, ErrWrongType
 	}
 	return db.setMembers(k), nil
@@ -339,7 +339,7 @@ func (db *RedisDB) IsMember(k, v string) (bool, error) {
 	if !db.exists(k) {
 		return false, ErrKeyNotFound
 	}
-	if db.t(k) != "set" {
+	if db.t(k) != keyTypeSet {
 		return false, ErrWrongType
 	}
 	return db.setIsMember(k, v), nil
@@ -358,7 +358,7 @@ func (db *RedisDB) HKeys(key string) ([]string, error) {
 	if !db.exists(key) {
 		return nil, ErrKeyNotFound
 	}
-	if db.t(key) != "hash" {
+	if db.t(key) != keyTypeHash {
 		return nil, ErrWrongType
 	}
 	return db.hashFields(key), nil
@@ -569,7 +569,7 @@ func (db *RedisDB) SRem(k string, fields ...string) (int, error) {
 	if !db.exists(k) {
 		return 0, ErrKeyNotFound
 	}
-	if db.t(k) != "set" {
+	if db.t(k) != keyTypeSet {
 		return 0, ErrWrongType
 	}
 	return db.setRem(k, fields...), nil
@@ -586,7 +586,7 @@ func (db *RedisDB) ZAdd(k string, score float64, member string) (bool, error) {
 	defer db.master.Unlock()
 	defer db.master.signal.Broadcast()
 
-	if db.exists(k) && db.t(k) != "zset" {
+	if db.exists(k) && db.t(k) != keyTypeSortedSet {
 		return false, ErrWrongType
 	}
 	return db.ssetAdd(k, score, member), nil
@@ -605,7 +605,7 @@ func (db *RedisDB) ZMembers(k string) ([]string, error) {
 	if !db.exists(k) {
 		return nil, ErrKeyNotFound
 	}
-	if db.t(k) != "zset" {
+	if db.t(k) != keyTypeSortedSet {
 		return nil, ErrWrongType
 	}
 	return db.ssetMembers(k), nil
@@ -624,7 +624,7 @@ func (db *RedisDB) SortedSet(k string) (map[string]float64, error) {
 	if !db.exists(k) {
 		return nil, ErrKeyNotFound
 	}
-	if db.t(k) != "zset" {
+	if db.t(k) != keyTypeSortedSet {
 		return nil, ErrWrongType
 	}
 	return db.sortedSet(k), nil
@@ -644,7 +644,7 @@ func (db *RedisDB) ZRem(k, member string) (bool, error) {
 	if !db.exists(k) {
 		return false, ErrKeyNotFound
 	}
-	if db.t(k) != "zset" {
+	if db.t(k) != keyTypeSortedSet {
 		return false, ErrWrongType
 	}
 	return db.ssetRem(k, member), nil
@@ -663,7 +663,7 @@ func (db *RedisDB) ZScore(k, member string) (float64, error) {
 	if !db.exists(k) {
 		return 0, ErrKeyNotFound
 	}
-	if db.t(k) != "zset" {
+	if db.t(k) != keyTypeSortedSet {
 		return 0, ErrWrongType
 	}
 	return db.ssetScore(k, member), nil
@@ -681,7 +681,7 @@ func (db *RedisDB) ZMScore(k string, members []string) ([]float64, error) {
 	if !db.exists(k) {
 		return nil, ErrKeyNotFound
 	}
-	if db.t(k) != "zset" {
+	if db.t(k) != keyTypeSortedSet {
 		return nil, ErrWrongType
 	}
 	return db.ssetMScore(k, members), nil
@@ -783,7 +783,7 @@ func (db *RedisDB) HllAdd(k string, elems ...string) (int, error) {
 	db.master.Lock()
 	defer db.master.Unlock()
 
-	if db.exists(k) && db.t(k) != "hll" {
+	if db.exists(k) && db.t(k) != keyTypeHll {
 		return 0, ErrWrongType
 	}
 	return db.hllAdd(k, elems...), nil

--- a/miniredis.go
+++ b/miniredis.go
@@ -373,15 +373,15 @@ func (m *Miniredis) Server() *server.Server {
 	return m.srv
 }
 
-// Dump returns a text version of the selected DB, usable for debugging.
+// DebugDump returns a text version of the selected DB, usable for debugging.
 //
-// Dump limits the maximum length of each key:value to "DumpMaxLineLen" characters.
+// DebugDump limits the maximum length of each key:value to "DumpMaxLineLen" characters.
 // To increase that, call something like:
 //
 //	miniredis.DumpMaxLineLen = 1024
 //	mr, _ = miniredis.Run()
-//	mr.Dump()
-func (m *Miniredis) Dump() string {
+//	mr.DebugDump()
+func (m *Miniredis) DebugDump() string {
 	m.Lock()
 	defer m.Unlock()
 

--- a/miniredis.go
+++ b/miniredis.go
@@ -404,25 +404,25 @@ func (m *Miniredis) Dump() string {
 		r += fmt.Sprintf("- %s\n", k)
 		t := db.t(k)
 		switch t {
-		case "string":
+		case keyTypeString:
 			r += fmt.Sprintf("%s%s\n", indent, v(db.stringKeys[k]))
-		case "hash":
+		case keyTypeHash:
 			for _, hk := range db.hashFields(k) {
 				r += fmt.Sprintf("%s%s: %s\n", indent, hk, v(db.hashGet(k, hk)))
 			}
-		case "list":
+		case keyTypeList:
 			for _, lk := range db.listKeys[k] {
 				r += fmt.Sprintf("%s%s\n", indent, v(lk))
 			}
-		case "set":
+		case keyTypeSet:
 			for _, mk := range db.setMembers(k) {
 				r += fmt.Sprintf("%s%s\n", indent, v(mk))
 			}
-		case "zset":
+		case keyTypeSortedSet:
 			for _, el := range db.ssetElements(k) {
 				r += fmt.Sprintf("%s%f: %s\n", indent, el.score, v(el.member))
 			}
-		case "stream":
+		case keyTypeStream:
 			for _, entry := range db.streamKeys[k].entries {
 				r += fmt.Sprintf("%s%s\n", indent, entry.ID)
 				ev := entry.Values
@@ -430,7 +430,7 @@ func (m *Miniredis) Dump() string {
 					r += fmt.Sprintf("%s%s%s: %s\n", indent, indent, v(ev[2*i]), v(ev[2*i+1]))
 				}
 			}
-		case "hll":
+		case keyTypeHll:
 			for _, entry := range db.hllKeys {
 				r += fmt.Sprintf("%s%s\n", indent, v(string(entry.Bytes())))
 			}
@@ -703,19 +703,19 @@ func (m *Miniredis) copy(
 	}
 
 	switch srcDB.t(src) {
-	case "string":
+	case keyTypeString:
 		destDB.stringKeys[dst] = srcDB.stringKeys[src]
-	case "hash":
+	case keyTypeHash:
 		destDB.hashKeys[dst] = copyHashKey(srcDB.hashKeys[src])
-	case "list":
+	case keyTypeList:
 		destDB.listKeys[dst] = copyListKey(srcDB.listKeys[src])
-	case "set":
+	case keyTypeSet:
 		destDB.setKeys[dst] = copySetKey(srcDB.setKeys[src])
-	case "zset":
+	case keyTypeSortedSet:
 		destDB.sortedsetKeys[dst] = copySortedSet(srcDB.sortedsetKeys[src])
-	case "stream":
+	case keyTypeStream:
 		destDB.streamKeys[dst] = srcDB.streamKeys[src].copy()
-	case "hll":
+	case keyTypeHll:
 		destDB.hllKeys[dst] = srcDB.hllKeys[src].copy()
 	default:
 		panic("missing case")

--- a/miniredis.go
+++ b/miniredis.go
@@ -373,15 +373,15 @@ func (m *Miniredis) Server() *server.Server {
 	return m.srv
 }
 
-// DebugDump returns a text version of the selected DB, usable for debugging.
+// Dump returns a text version of the selected DB, usable for debugging.
 //
-// DebugDump limits the maximum length of each key:value to "DumpMaxLineLen" characters.
+// Dump limits the maximum length of each key:value to "DumpMaxLineLen" characters.
 // To increase that, call something like:
 //
 //	miniredis.DumpMaxLineLen = 1024
 //	mr, _ = miniredis.Run()
-//	mr.DebugDump()
-func (m *Miniredis) DebugDump() string {
+//	mr.Dump()
+func (m *Miniredis) Dump() string {
 	m.Lock()
 	defer m.Unlock()
 

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -242,36 +242,96 @@ func TestPool(t *testing.T) {
 	c.Close()
 }
 */
-
 func TestMiniredis_isValidCMD(t *testing.T) {
+	two := 2
 	testCases := []struct {
 		name         string
 		isAuthorized bool
 		isInPUBSUB   bool
+		args         []string
+		minArgs      int
+		maxArgs      *int
 		wantResult   bool
 	}{
 		{
 			name:         "Client is not authorized, no PUBSUB mode",
 			isAuthorized: false,
 			isInPUBSUB:   false,
+			args:         []string{},
+			minArgs:      0,
+			maxArgs:      nil,
 			wantResult:   false,
 		},
 		{
 			name:         "Client is not authorized, PUBSUB mode",
 			isAuthorized: false,
 			isInPUBSUB:   true,
+			args:         []string{},
+			minArgs:      0,
+			maxArgs:      nil,
 			wantResult:   false,
 		},
 		{
 			name:         "Client is authorized, PUBSUB mode",
 			isAuthorized: true,
 			isInPUBSUB:   true,
+			args:         []string{},
+			minArgs:      0,
+			maxArgs:      nil,
 			wantResult:   false,
 		},
 		{
 			name:         "Client is authorized, no PUBSUB mode",
 			isAuthorized: true,
 			isInPUBSUB:   false,
+			args:         []string{},
+			minArgs:      0,
+			maxArgs:      nil,
+			wantResult:   true,
+		},
+		{
+			name:         "Too few args",
+			isAuthorized: true,
+			isInPUBSUB:   false,
+			args:         []string{},
+			minArgs:      1,
+			maxArgs:      nil,
+			wantResult:   false,
+		},
+		{
+			name:         "Too many args",
+			isAuthorized: true,
+			isInPUBSUB:   false,
+			args:         []string{"a", "b", "c"},
+			minArgs:      1,
+			maxArgs:      &two,
+			wantResult:   false,
+		},
+		{
+			name:         "Exact args",
+			isAuthorized: true,
+			isInPUBSUB:   false,
+			args:         []string{"a", "b"},
+			minArgs:      2,
+			maxArgs:      &two,
+			wantResult:   true,
+		},
+		{
+			name:         "Surplus args (no max)",
+			isAuthorized: true,
+			isInPUBSUB:   false,
+			args:         []string{"a", "b", "c"},
+			minArgs:      1,
+			maxArgs:      nil,
+			wantResult:   true,
+		},
+		{
+			name:         "Exact args (no max)",
+			isAuthorized: true,
+			isInPUBSUB:   false,
+			args:         []string{"a"},
+			minArgs:      1,
+			maxArgs:      nil,
 			wantResult:   true,
 		},
 	}
@@ -294,7 +354,7 @@ func TestMiniredis_isValidCMD(t *testing.T) {
 				}
 			}
 
-			assert(t, tc.wantResult == m.isValidCMD(c, "example_cmd"), "fail")
+			assert(t, tc.wantResult == m.isValidCMD(c, "example_cmd", tc.args, argRequirements{tc.minArgs, tc.maxArgs}), "fail")
 		})
 	}
 }

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -76,13 +76,13 @@ func TestAddr(t *testing.T) {
 	mustDo(t, c, "PING", proto.Inline("PONG"))
 }
 
-func TestDump(t *testing.T) {
+func TestDebugDump(t *testing.T) {
 	s := RunT(t)
 	s.Set("aap", "noot")
 	s.Set("vuur", "mies")
 	s.HSet("ahash", "aap", "noot")
 	s.HSet("ahash", "vuur", "mies")
-	if have, want := s.Dump(), `- aap
+	if have, want := s.DebugDump(), `- aap
    "noot"
 - ahash
    aap: "noot"
@@ -96,7 +96,7 @@ func TestDump(t *testing.T) {
 	// Tricky whitespace
 	s.Select(1)
 	s.Set("whitespace", "foo\nbar\tbaz!")
-	if have, want := s.Dump(), `- whitespace
+	if have, want := s.DebugDump(), `- whitespace
    "foo\nbar\tbaz!"
 `; have != want {
 		t.Errorf("have: %q, want: %q", have, want)
@@ -107,7 +107,7 @@ func TestDump(t *testing.T) {
 	s.Set("long", "This is a rather long key, with some fox jumping over a fence or something.")
 	s.Set("countonme", "0123456789012345678901234567890123456789012345678901234567890123456789")
 	s.HSet("hlong", "long", "This is another rather long key, with some fox jumping over a fence or something.")
-	if have, want := s.Dump(), `- countonme
+	if have, want := s.DebugDump(), `- countonme
    "01234567890123456789012345678901234567890123456789012"...(70)
 - hlong
    long: "This is another rather long key, with some fox jumpin"...(81)
@@ -123,7 +123,7 @@ func TestDumpList(t *testing.T) {
 	s.Push("elements", "earth")
 	s.Push("elements", "wind")
 	s.Push("elements", "fire")
-	if have, want := s.Dump(), `- elements
+	if have, want := s.DebugDump(), `- elements
    "earth"
    "wind"
    "fire"
@@ -137,7 +137,7 @@ func TestDumpSet(t *testing.T) {
 	s.SetAdd("elements", "earth")
 	s.SetAdd("elements", "wind")
 	s.SetAdd("elements", "fire")
-	if have, want := s.Dump(), `- elements
+	if have, want := s.DebugDump(), `- elements
    "earth"
    "fire"
    "wind"
@@ -151,7 +151,7 @@ func TestDumpSortedSet(t *testing.T) {
 	s.ZAdd("elements", 2.0, "wind")
 	s.ZAdd("elements", 3.0, "earth")
 	s.ZAdd("elements", 1.0, "fire")
-	if have, want := s.Dump(), `- elements
+	if have, want := s.DebugDump(), `- elements
    1.000000: "fire"
    2.000000: "wind"
    3.000000: "earth"
@@ -165,7 +165,7 @@ func TestDumpStream(t *testing.T) {
 	s.XAdd("elements", "0-1", []string{"name", "earth"})
 	s.XAdd("elements", "123456789-0", []string{"name", "wind"})
 	s.XAdd("elements", "123456789-1", []string{"name", "fire"})
-	if have, want := s.Dump(), `- elements
+	if have, want := s.DebugDump(), `- elements
    0-1
       "name": "earth"
    123456789-0
@@ -177,7 +177,7 @@ func TestDumpStream(t *testing.T) {
 	}
 
 	s.XAdd("elements", "*", []string{"name", "Leeloo"})
-	fullHave := s.Dump()
+	fullHave := s.DebugDump()
 	have := strings.Split(fullHave, "\n")[8]
 	want := `      "name": "Leeloo"`
 	if have != want {
@@ -226,21 +226,22 @@ func TestExpireWithFastForward(t *testing.T) {
 
 /*
 we don't have the redis client anymore
-func TestPool(t *testing.T) {
-	s, err := Run()
-	ok(t, err)
-	defer s.Close()
 
-	pool := &redis.Pool{
-		MaxIdle:     1,
-		IdleTimeout: 5 * time.Second,
-		Dial: func() (redis.Conn, error) {
-			return redis.Dial("tcp", s.Addr())
-		},
+	func TestPool(t *testing.T) {
+		s, err := Run()
+		ok(t, err)
+		defer s.Close()
+
+		pool := &redis.Pool{
+			MaxIdle:     1,
+			IdleTimeout: 5 * time.Second,
+			Dial: func() (redis.Conn, error) {
+				return redis.Dial("tcp", s.Addr())
+			},
+		}
+		c := pool.Get()
+		c.Close()
 	}
-	c := pool.Get()
-	c.Close()
-}
 */
 func TestMiniredis_isValidCMD(t *testing.T) {
 	two := 2

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -76,13 +76,13 @@ func TestAddr(t *testing.T) {
 	mustDo(t, c, "PING", proto.Inline("PONG"))
 }
 
-func TestDebugDump(t *testing.T) {
+func TestDump(t *testing.T) {
 	s := RunT(t)
 	s.Set("aap", "noot")
 	s.Set("vuur", "mies")
 	s.HSet("ahash", "aap", "noot")
 	s.HSet("ahash", "vuur", "mies")
-	if have, want := s.DebugDump(), `- aap
+	if have, want := s.Dump(), `- aap
    "noot"
 - ahash
    aap: "noot"
@@ -96,7 +96,7 @@ func TestDebugDump(t *testing.T) {
 	// Tricky whitespace
 	s.Select(1)
 	s.Set("whitespace", "foo\nbar\tbaz!")
-	if have, want := s.DebugDump(), `- whitespace
+	if have, want := s.Dump(), `- whitespace
    "foo\nbar\tbaz!"
 `; have != want {
 		t.Errorf("have: %q, want: %q", have, want)
@@ -107,7 +107,7 @@ func TestDebugDump(t *testing.T) {
 	s.Set("long", "This is a rather long key, with some fox jumping over a fence or something.")
 	s.Set("countonme", "0123456789012345678901234567890123456789012345678901234567890123456789")
 	s.HSet("hlong", "long", "This is another rather long key, with some fox jumping over a fence or something.")
-	if have, want := s.DebugDump(), `- countonme
+	if have, want := s.Dump(), `- countonme
    "01234567890123456789012345678901234567890123456789012"...(70)
 - hlong
    long: "This is another rather long key, with some fox jumpin"...(81)
@@ -123,7 +123,7 @@ func TestDumpList(t *testing.T) {
 	s.Push("elements", "earth")
 	s.Push("elements", "wind")
 	s.Push("elements", "fire")
-	if have, want := s.DebugDump(), `- elements
+	if have, want := s.Dump(), `- elements
    "earth"
    "wind"
    "fire"
@@ -137,7 +137,7 @@ func TestDumpSet(t *testing.T) {
 	s.SetAdd("elements", "earth")
 	s.SetAdd("elements", "wind")
 	s.SetAdd("elements", "fire")
-	if have, want := s.DebugDump(), `- elements
+	if have, want := s.Dump(), `- elements
    "earth"
    "fire"
    "wind"
@@ -151,7 +151,7 @@ func TestDumpSortedSet(t *testing.T) {
 	s.ZAdd("elements", 2.0, "wind")
 	s.ZAdd("elements", 3.0, "earth")
 	s.ZAdd("elements", 1.0, "fire")
-	if have, want := s.DebugDump(), `- elements
+	if have, want := s.Dump(), `- elements
    1.000000: "fire"
    2.000000: "wind"
    3.000000: "earth"
@@ -165,7 +165,7 @@ func TestDumpStream(t *testing.T) {
 	s.XAdd("elements", "0-1", []string{"name", "earth"})
 	s.XAdd("elements", "123456789-0", []string{"name", "wind"})
 	s.XAdd("elements", "123456789-1", []string{"name", "fire"})
-	if have, want := s.DebugDump(), `- elements
+	if have, want := s.Dump(), `- elements
    0-1
       "name": "earth"
    123456789-0
@@ -177,7 +177,7 @@ func TestDumpStream(t *testing.T) {
 	}
 
 	s.XAdd("elements", "*", []string{"name", "Leeloo"})
-	fullHave := s.DebugDump()
+	fullHave := s.Dump()
 	have := strings.Split(fullHave, "\n")[8]
 	want := `      "name": "Leeloo"`
 	if have != want {

--- a/redis.go
+++ b/redis.go
@@ -13,6 +13,16 @@ import (
 )
 
 const (
+	keyTypeString    = "string"
+	keyTypeHash      = "hash"
+	keyTypeList      = "list"
+	keyTypeSet       = "set"
+	keyTypeHll       = "hll"
+	keyTypeSortedSet = "zset"
+	keyTypeStream    = "stream"
+)
+
+const (
 	msgWrongType            = "WRONGTYPE Operation against a key holding the wrong kind of value"
 	msgNotValidHllValue     = "WRONGTYPE Key is not a valid HyperLogLog string value."
 	msgInvalidInt           = "ERR value is not an integer or out of range"


### PR DESCRIPTION
Closes #401 

Simple implementation for `DUMP` and `RESTORE` which just supports string keys:

- Attempting to dump a different key type will produce `WRONGTYPE Operation against a key holding the wrong kind of value`
- For [RESTORE](https://redis.io/docs/latest/commands/restore/) I've implemented the `REPLACE` and `ABSTTL` optional flags, but not `IDLETIME` or `FREQ` (wasn't immediately obvious to me what these were :woman_shrugging: )

I have also:

 - Renamed the existing `Dump` to `DebugDump` to avoid confusion
 - Extracted constants for the various key types
 - Collected common validation into `validCMD` and plugged it in for all the existing generic commands. Happy to do this for the remainder as well if the approach looks good to you :smile: 