### PR TITLE
un-implent "SCAN COUNT" so cursors work as they should

### DIFF
--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -671,28 +671,14 @@ func (m *Miniredis) cmdScan(c *server.Peer, cmd string, args []string) {
 			keys, _ = matchKeys(keys, opts.match)
 		}
 
+		// we only ever return all at once, so no non-zero cursor can every be valid
+		if opts.cursor != 0 {
+			c.WriteLen(2)
+			c.WriteBulk("0") // no next cursor
+			c.WriteLen(0)    // no elements
+			return
+		}
 		cursorValue := 0 // we don't use cursors
-		/*
-			low := opts.cursor
-			high := low + opts.count
-			// validate high is correct
-			if high > len(keys) || high == 0 {
-				high = len(keys)
-			}
-			if opts.cursor > high {
-				// invalid cursor
-				c.WriteLen(2)
-				c.WriteBulk("0") // no next cursor
-				c.WriteLen(0)    // no elements
-				return
-			}
-			cursorValue := low + opts.count
-			if cursorValue >= len(keys) {
-				cursorValue = 0 // no next cursor
-			}
-			keys = keys[low:high]
-		*/
-
 		c.WriteLen(2)
 		c.WriteBulk(fmt.Sprintf("%d", cursorValue))
 		c.WriteLen(len(keys))

--- a/cmd_generic_test.go
+++ b/cmd_generic_test.go
@@ -758,14 +758,22 @@ func TestScan(t *testing.T) {
 		s.Set("v8", "value")
 		s.Set("v9", "value")
 
+		// count is ignored
 		mustDo(t, c,
 			"SCAN", "0", "COUNT", "3",
 			proto.Array(
-				proto.String("3"),
+				proto.String("0"),
 				proto.Array(
 					proto.String("key"),
 					proto.String("v1"),
 					proto.String("v2"),
+					proto.String("v3"),
+					proto.String("v4"),
+					proto.String("v5"),
+					proto.String("v6"),
+					proto.String("v7"),
+					proto.String("v8"),
+					proto.String("v9"),
 				),
 			),
 		)
@@ -773,12 +781,8 @@ func TestScan(t *testing.T) {
 		mustDo(t, c,
 			"SCAN", "3", "COUNT", "3",
 			proto.Array(
-				proto.String("6"),
-				proto.Array(
-					proto.String("v3"),
-					proto.String("v4"),
-					proto.String("v5"),
-				),
+				proto.String("0"),
+				proto.Array(),
 			),
 		)
 	})


### PR DESCRIPTION
This fixes #413:

"count" is allowed to be ignored, and there are some guarantees about which keys show up.

Another way to implement this would be to add a global "version counter", use that as the "cursor", and start the loop from the beginning whenever that changed:

> A given element may be returned multiple times. It is up to the application to handle the case of duplicated elements, for example only using the returned elements in order to perform operations that are safe when re-applied multiple times.

https://redis.io/docs/latest/commands/scan/#scan-guarantees