### PR TITLE
Add Dial() and ClockTTL() for in-memory use and testing/synctest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,42 @@ which case time.Now() will be used.
 SetTime() also sets the value returned by TIME, which defaults to time.Now().
 It is not updated by FastForward, only by SetTime.
 
+`m.ClockTTL(true)` makes TTLs decrease as the clock (time.Now(), or the
+SetTime() value) advances, instead of only via FastForward. Expired keys are
+removed lazily, whenever a database is accessed via a command or a
+Miniredis-level accessor. Combined with SetTime() the expiry stays coherent
+with TIME and (P)EXPIREAT. Note that against the wall clock this makes expiry
+depend on test execution speed, which is why it's not the default.
+
+## testing/synctest
+
+miniredis works inside a `testing/synctest` bubble (Go 1.25+). Since real TCP
+connections can't be used there, connect with `m.Dial()`, which serves the
+connection on an in-memory pipe — most redis clients accept it as a custom
+dialer. `NewMiniRedis()` is the non-started constructor: with `Dial()` no
+listener is ever created. Inside a bubble `time.Now()` is the bubble's fake
+clock, so with `ClockTTL(true)` a plain `time.Sleep()` expires keys — no
+FastForward needed:
+
+``` Go
+synctest.Test(t, func(t *testing.T) {
+	m := miniredis.NewMiniRedis()
+	defer m.Close()
+	m.ClockTTL(true)
+
+	client := redis.NewClient(&redis.Options{
+		Dialer: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return m.Dial()
+		},
+	})
+
+	ctx := context.Background()
+	client.Set(ctx, "session", "v", time.Hour)
+	time.Sleep(time.Hour + time.Second) // instant, and deterministic
+	// key is expired now
+})
+```
+
 ## Randomness and Seed()
 
 Miniredis will use `math/rand`'s global RNG for randomness unless a seed is

--- a/miniredis.go
+++ b/miniredis.go
@@ -65,6 +65,8 @@ type Miniredis struct {
 	scripts     map[string]string // sha1 -> lua src
 	signal      *sync.Cond
 	now         time.Time // time.Now() if not set.
+	clockTTL    bool      // decrease TTLs as the clock advances
+	lastTick    time.Time // last time TTLs were advanced, if clockTTL is set
 	subscribers map[*Subscriber]struct{}
 	rand        *rand.Rand
 	Ctx         context.Context
@@ -325,6 +327,7 @@ func (m *Miniredis) DB(i int) *RedisDB {
 
 // get DB. No locks!
 func (m *Miniredis) db(i int) *RedisDB {
+	m.tickLocked()
 	if db, ok := m.dbs[i]; ok {
 		return db
 	}
@@ -498,6 +501,50 @@ func (m *Miniredis) SetTime(t time.Time) {
 	m.Lock()
 	defer m.Unlock()
 	m.now = t
+	// keep the ClockTTL baseline sane when the clock jumps backwards; a
+	// forward jump stays pending until the next tick.
+	if m.clockTTL && t.Before(m.lastTick) {
+		m.lastTick = t
+	}
+}
+
+// ClockTTL makes TTLs (both key and hash field TTLs) decrease as the clock
+// advances, instead of only via FastForward(). The clock is time.Now(), or
+// the value set with SetTime(). Expired keys are removed lazily, whenever a
+// command or a Miniredis-level accessor touches a database; a *RedisDB held
+// directly does not trigger expiry.
+//
+// With SetTime() this gives deterministic clock-driven expiry: moving the
+// clock forward expires keys, and unlike FastForward() the expiry stays
+// coherent with TIME and (P)EXPIREAT, which follow SetTime() as well.
+//
+// It also makes miniredis work inside a testing/synctest bubble, where
+// time.Now() is the bubble's deterministic fake clock: a plain time.Sleep()
+// there expires keys. Without SetTime() and outside a bubble, TTLs run
+// against the wall clock, which makes expiry depend on test execution
+// speed — usually not what you want in a unittest.
+func (m *Miniredis) ClockTTL(enabled bool) {
+	m.Lock()
+	defer m.Unlock()
+	m.clockTTL = enabled
+	m.lastTick = m.effectiveNow()
+}
+
+// advance TTLs by the clock time elapsed since the last tick. Called with the
+// lock held on every database access, when ClockTTL is enabled.
+func (m *Miniredis) tickLocked() {
+	if !m.clockTTL {
+		return
+	}
+	now := m.effectiveNow()
+	elapsed := now.Sub(m.lastTick)
+	if elapsed <= 0 {
+		return
+	}
+	m.lastTick = now
+	for _, db := range m.dbs {
+		db.fastForward(elapsed)
+	}
 }
 
 // make every command return this message. For example:

--- a/miniredis.go
+++ b/miniredis.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"math/rand"
+	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -209,8 +210,14 @@ func (m *Miniredis) StartAddrTLS(addr string, cfg *tls.Config) error {
 func (m *Miniredis) start(s *server.Server) error {
 	m.Lock()
 	defer m.Unlock()
+	return m.startLocked(s)
+}
+
+func (m *Miniredis) startLocked(s *server.Server) error {
 	m.srv = s
-	m.port = s.Addr().Port
+	if a := s.Addr(); a != nil {
+		m.port = a.Port
+	}
 
 	commandsConnection(m)
 	commandsGeneric(m)
@@ -231,6 +238,36 @@ func (m *Miniredis) start(s *server.Server) error {
 	commandsObject(m)
 
 	return nil
+}
+
+// Dial returns an in-memory client connection to the server, served on a
+// net.Pipe: no listener or port is involved. A non-started Miniredis is
+// started without a listener, so NewMiniRedis() + Dial() gives a working
+// server which never touches the network. Note that Addr() has no address to
+// return in that case.
+//
+// Dial fits the Dialer option of most redis clients, and makes miniredis
+// usable inside a testing/synctest bubble, where real sockets can't be used:
+//
+//	client := redis.NewClient(&redis.Options{
+//		Dialer: func(ctx context.Context, _, _ string) (net.Conn, error) {
+//			return m.Dial()
+//		},
+//	})
+func (m *Miniredis) Dial() (net.Conn, error) {
+	m.Lock()
+	if m.srv == nil {
+		if err := m.startLocked(server.NewServerConn()); err != nil {
+			m.Unlock()
+			return nil, err
+		}
+	}
+	srv := m.srv
+	m.Unlock()
+
+	c, s := net.Pipe()
+	srv.ServeConn(s)
+	return c, nil
 }
 
 // Restart restarts a Close()d server on the same port. Values will be
@@ -322,7 +359,11 @@ func (m *Miniredis) swapDB(i, j int) bool {
 func (m *Miniredis) Addr() string {
 	m.Lock()
 	defer m.Unlock()
-	return m.srv.Addr().String()
+	a := m.srv.Addr()
+	if a == nil {
+		return ""
+	}
+	return a.String()
 }
 
 // Host returns the host part of Addr().

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -436,3 +436,128 @@ func TestDialClose(t *testing.T) {
 		t.Fatal("expected an error on a closed server")
 	}
 }
+
+// With ClockTTL, advancing the clock with SetTime expires keys.
+func TestClockTTL(t *testing.T) {
+	m := NewMiniRedis()
+	defer m.Close()
+
+	start := time.Date(2022, 3, 4, 13, 0, 0, 0, time.UTC)
+	m.SetTime(start)
+	m.ClockTTL(true)
+
+	conn, err := m.Dial()
+	ok(t, err)
+	c := proto.NewClient(conn)
+	defer c.Close()
+
+	mustOK(t, c, "SET", "foo", "bar", "EX", "100")
+	mustDo(t, c, "TTL", "foo", proto.Int(100))
+
+	m.SetTime(start.Add(30 * time.Second))
+	mustDo(t, c, "TTL", "foo", proto.Int(70))
+	mustDo(t, c, "GET", "foo", proto.String("bar"))
+
+	m.SetTime(start.Add(101 * time.Second))
+	mustNil(t, c, "GET", "foo")
+	mustDo(t, c, "TTL", "foo", proto.Int(-2))
+	mustDo(t, c, "EXISTS", "foo", proto.Int(0))
+}
+
+// ClockTTL called before SetTime: the tick baseline follows SetTime, so the
+// order of the two calls doesn't matter.
+func TestClockTTLThenSetTime(t *testing.T) {
+	m := NewMiniRedis()
+	defer m.Close()
+
+	m.ClockTTL(true)
+	start := time.Date(2022, 3, 4, 13, 0, 0, 0, time.UTC)
+	m.SetTime(start)
+
+	conn, err := m.Dial()
+	ok(t, err)
+	c := proto.NewClient(conn)
+	defer c.Close()
+
+	mustOK(t, c, "SET", "foo", "bar", "EX", "100")
+	m.SetTime(start.Add(200 * time.Second))
+	mustNil(t, c, "GET", "foo")
+}
+
+// Without ClockTTL nothing changes: TTLs stay frozen when the clock moves.
+func TestClockTTLDisabled(t *testing.T) {
+	m := NewMiniRedis()
+	defer m.Close()
+
+	start := time.Date(2022, 3, 4, 13, 0, 0, 0, time.UTC)
+	m.SetTime(start)
+
+	conn, err := m.Dial()
+	ok(t, err)
+	c := proto.NewClient(conn)
+	defer c.Close()
+
+	mustOK(t, c, "SET", "foo", "bar", "EX", "100")
+	m.SetTime(start.Add(200 * time.Second))
+	mustDo(t, c, "GET", "foo", proto.String("bar"))
+	mustDo(t, c, "TTL", "foo", proto.Int(100))
+}
+
+// FastForward still works alongside ClockTTL.
+func TestClockTTLFastForward(t *testing.T) {
+	m := NewMiniRedis()
+	defer m.Close()
+
+	start := time.Date(2022, 3, 4, 13, 0, 0, 0, time.UTC)
+	m.SetTime(start)
+	m.ClockTTL(true)
+
+	conn, err := m.Dial()
+	ok(t, err)
+	c := proto.NewClient(conn)
+	defer c.Close()
+
+	mustOK(t, c, "SET", "foo", "bar", "EX", "100")
+	m.SetTime(start.Add(30 * time.Second))
+	m.FastForward(30 * time.Second)
+	mustDo(t, c, "TTL", "foo", proto.Int(40))
+}
+
+// The direct accessors see expiry too.
+func TestClockTTLDirect(t *testing.T) {
+	m := NewMiniRedis()
+	defer m.Close()
+
+	start := time.Date(2022, 3, 4, 13, 0, 0, 0, time.UTC)
+	m.SetTime(start)
+	m.ClockTTL(true)
+
+	m.Set("foo", "bar")
+	m.SetTTL("foo", 100*time.Second)
+	assert(t, m.Exists("foo"), "foo should exist before its TTL passes")
+
+	m.SetTime(start.Add(101 * time.Second))
+	assert(t, !m.Exists("foo"), "foo should be expired")
+}
+
+// Hash field TTLs decay with the clock too.
+func TestClockTTLHashFields(t *testing.T) {
+	m := NewMiniRedis()
+	defer m.Close()
+
+	start := time.Date(2022, 3, 4, 13, 0, 0, 0, time.UTC)
+	m.SetTime(start)
+	m.ClockTTL(true)
+
+	conn, err := m.Dial()
+	ok(t, err)
+	c := proto.NewClient(conn)
+	defer c.Close()
+
+	mustDo(t, c, "HSET", "myhash", "field1", "value1", "field2", "value2", proto.Int(2))
+	mustDo(t, c, "HEXPIRE", "myhash", "100", "FIELDS", "1", "field1", proto.Ints(1))
+
+	m.SetTime(start.Add(101 * time.Second))
+	mustNil(t, c, "HGET", "myhash", "field1")
+	mustDo(t, c, "HGET", "myhash", "field2", proto.String("value2"))
+}

--- a/miniredis_test.go
+++ b/miniredis_test.go
@@ -359,3 +359,80 @@ func TestMiniredis_isValidCMD(t *testing.T) {
 		})
 	}
 }
+
+// Dial on a non-started Miniredis: no TCP listener is ever created.
+func TestDial(t *testing.T) {
+	m := NewMiniRedis()
+	defer m.Close()
+
+	conn, err := m.Dial()
+	ok(t, err)
+	c := proto.NewClient(conn)
+	defer c.Close()
+
+	mustDo(t, c, "SET", "foo", "bar", proto.Inline("OK"))
+	mustDo(t, c, "GET", "foo", proto.String("bar"))
+
+	equals(t, "", m.Addr())
+}
+
+// Multiple Dial connections work independently.
+func TestDialMultiple(t *testing.T) {
+	m := NewMiniRedis()
+	defer m.Close()
+
+	conn1, err := m.Dial()
+	ok(t, err)
+	c1 := proto.NewClient(conn1)
+	defer c1.Close()
+
+	conn2, err := m.Dial()
+	ok(t, err)
+	c2 := proto.NewClient(conn2)
+	defer c2.Close()
+
+	mustDo(t, c1, "SET", "foo", "from-c1", proto.Inline("OK"))
+	mustDo(t, c2, "GET", "foo", proto.String("from-c1"))
+
+	mustDo(t, c1, "MULTI", proto.Inline("OK"))
+	mustDo(t, c1, "SET", "foo", "in-tx", proto.Inline("QUEUED"))
+	mustDo(t, c2, "GET", "foo", proto.String("from-c1"))
+	mustDo(t, c1, "EXEC", proto.Array(proto.Inline("OK")))
+	mustDo(t, c2, "GET", "foo", proto.String("in-tx"))
+}
+
+// Dial alongside a TCP listener started with Start().
+func TestDialWithStart(t *testing.T) {
+	m, err := Run()
+	ok(t, err)
+	defer m.Close()
+
+	tcp, err := proto.Dial(m.Addr())
+	ok(t, err)
+	defer tcp.Close()
+
+	conn, err := m.Dial()
+	ok(t, err)
+	pipe := proto.NewClient(conn)
+	defer pipe.Close()
+
+	mustDo(t, tcp, "SET", "foo", "bar", proto.Inline("OK"))
+	mustDo(t, pipe, "GET", "foo", proto.String("bar"))
+}
+
+// Close() unblocks and closes Dial connections.
+func TestDialClose(t *testing.T) {
+	m := NewMiniRedis()
+
+	conn, err := m.Dial()
+	ok(t, err)
+	c := proto.NewClient(conn)
+
+	mustDo(t, c, "PING", proto.Inline("PONG"))
+
+	m.Close()
+
+	if _, err := c.Do("PING"); err == nil {
+		t.Fatal("expected an error on a closed server")
+	}
+}

--- a/proto/client.go
+++ b/proto/client.go
@@ -11,6 +11,14 @@ type Client struct {
 	r *bufio.Reader
 }
 
+// NewClient wraps an existing connection, such as one from Miniredis.Dial().
+func NewClient(c net.Conn) *Client {
+	return &Client{
+		c: c,
+		r: bufio.NewReader(c),
+	}
+}
+
 func Dial(addr string) (*Client, error) {
 	c, err := net.Dial("tcp", addr)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -60,6 +60,15 @@ func NewServerTLS(addr string, cfg *tls.Config) (*Server, error) {
 	return newServer(l), nil
 }
 
+// NewServerConn makes a server without a listener. Connections are added
+// with ServeConn. Close with .Close().
+func NewServerConn() *Server {
+	return &Server{
+		cmds:  map[string]*cmdMeta{},
+		peers: map[net.Conn]struct{}{},
+	}
+}
+
 func newServer(l net.Listener) *Server {
 	s := Server{
 		cmds:  map[string]*cmdMeta{},
@@ -136,6 +145,9 @@ func (s *Server) Close() {
 		s.l.Close()
 	}
 	s.l = nil
+	for c := range s.peers {
+		c.Close()
+	}
 	s.mu.Unlock()
 
 	s.wg.Wait()


### PR DESCRIPTION
> **Disclosure:** this PR and the accompanying issue were written with LLM assistance. I've verified every claim against the miniredis source myself and validated the impact in my own project ([hookdeck/outpost](https://github.com/hookdeck/outpost)): a flaky sleep-based suite went from ~20s to <1s.

Implements the proposal in #445 — `testing/synctest` support. Rationale and design discussion live there; summary of the changes:

**`Miniredis.Dial()`** — an in-memory client connection served on a `net.Pipe`, no listener or port involved. A non-started Miniredis is started without a listener, so `NewMiniRedis()` + `Dial()` never touches the network. Fits the `Dialer` option of redis clients. Supporting changes: `server.NewServerConn()` (a `Server` with no listener; `Close()` now closes peers directly), `proto.NewClient(net.Conn)` to wrap an existing connection, and `Addr()` returns `""` instead of panicking when there's no listener.

**`Miniredis.ClockTTL(bool)`** — opt-in: TTLs (key and hash-field) decrease as the clock (`time.Now()`, or the `SetTime()` value) advances, instead of only via `FastForward()`. Expired keys are removed lazily on database access. Implemented as a tick that fast-forwards by the elapsed clock time since the last access — TTL storage and the existing expiry code paths are unchanged. `SetTime()` keeps the tick baseline sane when the clock jumps backwards; forward jumps expire keys as expected.

Default behavior is bit-identical for existing users: no new dependencies, no `testing/synctest` import (the integration is emergent from `time.Now()` and `net.Pipe`), `go 1.17` stands.

Tests: `dial_test.go` (pipe connections, multiple conns with MULTI/EXEC isolation, mixing with a TCP `Start()`, close behavior) and `clockttl_test.go` (expiry via `SetTime` advance, call-order independence, mode-off freezing, coexistence with `FastForward`, direct accessors). Full existing suite passes, including `-race`. README gains a short `testing/synctest` section with a usage example.
