### PR TITLE
Add BZPOPMIN and BZPOPMAX commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Implemented commands:
    - SUNION
    - SUNIONSTORE
  - Sorted Set keys
+   - BZPOPMAX
+   - BZPOPMIN
    - ZADD
    - ZCARD
    - ZCOUNT

--- a/cmd_sorted_set.go
+++ b/cmd_sorted_set.go
@@ -9,12 +9,15 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/alicebob/miniredis/v2/server"
 )
 
 // commandsSortedSet handles all sorted set operations.
 func commandsSortedSet(m *Miniredis) {
+	m.srv.Register("BZPOPMAX", m.cmdBzpopmax)
+	m.srv.Register("BZPOPMIN", m.cmdBzpopmin)
 	m.srv.Register("ZADD", m.cmdZadd)
 	m.srv.Register("ZCARD", m.cmdZcard, server.ReadOnlyOption())
 	m.srv.Register("ZCOUNT", m.cmdZcount, server.ReadOnlyOption())
@@ -1516,6 +1519,73 @@ func (m *Miniredis) cmdZpopmax(reverse bool) server.Cmd {
 			}
 		})
 	}
+}
+
+// BZPOPMAX
+func (m *Miniredis) cmdBzpopmax(c *server.Peer, cmd string, args []string) {
+	m.cmdBzpop(c, cmd, args, true)
+}
+
+// BZPOPMIN
+func (m *Miniredis) cmdBzpopmin(c *server.Peer, cmd string, args []string) {
+	m.cmdBzpop(c, cmd, args, false)
+}
+
+func (m *Miniredis) cmdBzpop(c *server.Peer, cmd string, args []string, reverse bool) {
+	if !m.isValidCMD(c, cmd, args, atLeast(2)) {
+		return
+	}
+
+	var opts struct {
+		keys    []string
+		timeout time.Duration
+	}
+
+	if ok := optDuration(c, args[len(args)-1], &opts.timeout); !ok {
+		return
+	}
+	opts.keys = args[:len(args)-1]
+
+	blocking(
+		m,
+		c,
+		opts.timeout,
+		func(c *server.Peer, ctx *connCtx) bool {
+			db := m.db(ctx.selectedDB)
+			for _, key := range opts.keys {
+				if !db.exists(key) {
+					continue
+				}
+				if db.t(key) != keyTypeSortedSet {
+					c.WriteError(msgWrongType)
+					return true
+				}
+
+				members := db.ssetMembers(key)
+				if len(members) == 0 {
+					continue
+				}
+				// members are ordered by score, ascending. ZPOPMIN takes the
+				// first, ZPOPMAX the last.
+				member := members[0]
+				if reverse {
+					member = members[len(members)-1]
+				}
+				score := db.ssetScore(key, member)
+				db.ssetRem(key, member)
+				c.WriteLen(3)
+				c.WriteBulk(key)
+				c.WriteBulk(member)
+				c.WriteFloat(score)
+				return true
+			}
+			return false
+		},
+		func(c *server.Peer) {
+			// timeout
+			c.WriteLen(-1)
+		},
+	)
 }
 
 // ZRANDMEMBER

--- a/cmd_sorted_set_test.go
+++ b/cmd_sorted_set_test.go
@@ -3,6 +3,7 @@ package miniredis
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2/proto"
 )
@@ -2255,4 +2256,151 @@ func TestSortedSetRandmember(t *testing.T) {
 			proto.Error(msgWrongType),
 		)
 	})
+}
+
+// Test BZPOPMIN
+func TestBzpopmin(t *testing.T) {
+	s, c := runWithClient(t)
+
+	t.Run("basic", func(t *testing.T) {
+		s.ZAdd("z", 1, "one")
+		s.ZAdd("z", 2, "two")
+		s.ZAdd("z", 3, "three")
+
+		mustDo(t, c,
+			"BZPOPMIN", "z", "1",
+			proto.Strings("z", "one", "1"),
+		)
+		mustDo(t, c,
+			"BZPOPMIN", "z", "1",
+			proto.Strings("z", "two", "2"),
+		)
+	})
+
+	t.Run("multiple keys", func(t *testing.T) {
+		// The first non-empty key is used, in order.
+		s.ZAdd("z2", 4, "vier")
+		mustDo(t, c,
+			"BZPOPMIN", "nosuch", "z2", "1",
+			proto.Strings("z2", "vier", "4"),
+		)
+	})
+
+	t.Run("errors", func(t *testing.T) {
+		mustDo(t, c,
+			"BZPOPMIN",
+			proto.Error(errWrongNumber("bzpopmin")),
+		)
+		mustDo(t, c,
+			"BZPOPMIN", "z",
+			proto.Error(errWrongNumber("bzpopmin")),
+		)
+		mustDo(t, c,
+			"BZPOPMIN", "z", "-1",
+			proto.Error(msgTimeoutNegative),
+		)
+		mustDo(t, c,
+			"BZPOPMIN", "z", "inf",
+			proto.Error(msgTimeoutIsOutOfRange),
+		)
+		mustDo(t, c,
+			"BZPOPMIN", "z", "notafloat",
+			proto.Error(msgInvalidTimeout),
+		)
+
+		s.Set("str", "value")
+		mustDo(t, c,
+			"BZPOPMIN", "str", "1",
+			proto.Error(msgWrongType),
+		)
+	})
+}
+
+// Test BZPOPMAX
+func TestBzpopmax(t *testing.T) {
+	s, c := runWithClient(t)
+
+	s.ZAdd("z", 1, "one")
+	s.ZAdd("z", 2, "two")
+	s.ZAdd("z", 3, "three")
+
+	mustDo(t, c,
+		"BZPOPMAX", "z", "1",
+		proto.Strings("z", "three", "3"),
+	)
+	mustDo(t, c,
+		"BZPOPMAX", "z", "1",
+		proto.Strings("z", "two", "2"),
+	)
+}
+
+func TestBzpopBlocking(t *testing.T) {
+	s, c := runWithClient(t)
+
+	got := goStrings(t, s, "BZPOPMIN", "z1", "z2", "0")
+	must1(t, c, "ZADD", "z2", "5", "aap")
+
+	select {
+	case have := <-got:
+		equals(t, proto.Strings("z2", "aap", "5"), have)
+	case <-time.After(500 * time.Millisecond):
+		t.Error("BZPOPMIN took too long")
+	}
+}
+
+func TestBzpopTimeout(t *testing.T) {
+	s := RunT(t)
+
+	got := goStrings(t, s, "BZPOPMIN", "z1", "0.1")
+	select {
+	case have := <-got:
+		equals(t, proto.NilList, have)
+	case <-time.After(200 * time.Millisecond):
+		t.Error("BZPOPMIN took too long")
+	}
+}
+
+func TestBzpopTx(t *testing.T) {
+	// BZPOPMIN in a transaction behaves as if the timeout triggers right away.
+	s, c := runWithClient(t)
+
+	{
+		mustOK(t, c, "MULTI")
+		mustDo(t, c,
+			"BZPOPMIN", "z1", "3",
+			proto.Inline("QUEUED"),
+		)
+		mustDo(t, c,
+			"SET", "foo", "bar",
+			proto.Inline("QUEUED"),
+		)
+		mustDo(t, c,
+			"EXEC",
+			proto.Array(
+				proto.NilList,
+				proto.Inline("OK"),
+			),
+		)
+	}
+
+	// Now with a member present.
+	s.ZAdd("z1", 1, "e1")
+	{
+		mustOK(t, c, "MULTI")
+		mustDo(t, c,
+			"BZPOPMIN", "z1", "3",
+			proto.Inline("QUEUED"),
+		)
+		mustDo(t, c,
+			"SET", "foo", "bar",
+			proto.Inline("QUEUED"),
+		)
+		mustDo(t, c,
+			"EXEC",
+			proto.Array(
+				proto.Strings("z1", "e1", "1"),
+				proto.Inline("OK"),
+			),
+		)
+	}
 }

--- a/integration/sorted_set_test.go
+++ b/integration/sorted_set_test.go
@@ -978,3 +978,32 @@ func TestZMScore(t *testing.T) {
 		c.Error("wrong kind", "ZMSCORE", "str", "key1")
 	})
 }
+
+func TestBzpopminmax(t *testing.T) {
+	skip(t)
+	testRaw(t, func(c *client) {
+		c.Do("ZADD", "set:bzpop", "1.0", "key1")
+		c.Do("ZADD", "set:bzpop", "2.0", "key2")
+		c.Do("ZADD", "set:bzpop", "3.0", "key3")
+
+		c.Do("BZPOPMIN", "set:bzpop", "1")
+		c.Do("BZPOPMAX", "set:bzpop", "1")
+
+		// First non-empty key of several.
+		c.Do("BZPOPMIN", "nosuch", "set:bzpop", "1")
+
+		// Nothing left, so times out.
+		c.Do("BZPOPMIN", "set:bzpop", "0.1")
+		c.Do("EXISTS", "set:bzpop")
+
+		// Wrong args
+		c.Error("wrong number", "BZPOPMIN")
+		c.Error("wrong number", "BZPOPMIN", "set:bzpop")
+		c.Error("not a float", "BZPOPMIN", "set:bzpop", "X")
+		c.Error("timeout is negative", "BZPOPMIN", "set:bzpop", "-1")
+		c.Error("timeout is out of range", "BZPOPMIN", "set:bzpop", "inf")
+
+		c.Do("SET", "str", "I am a string")
+		c.Error("wrong kind", "BZPOPMIN", "str", "1")
+	})
+}


### PR DESCRIPTION
From #428. These are the blocking sorted set pops, and they mirror the BLPOP/BRPOP list commands that are already here. BZPOPMIN pops the member with the lowest score, BZPOPMAX the highest, from the first non-empty key. On timeout you get a nil array.

I left BZMPOP out for now since there is no ZMPOP (or LMPOP/BLMPOP) yet, so the whole mpop family is missing and that felt like a separate change. Happy to do it as a follow up if you want it.

Added unit tests plus an integration test that passes against real redis (INT=1).