### PR TITLE
Fix panic on RENAME when new key is equal to old key

### DIFF
--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -472,11 +472,6 @@ func (m *Miniredis) cmdRename(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
-		if opts.from == opts.to {
-			c.WriteOK()
-			return
-		}
-
 		db.rename(opts.from, opts.to)
 		c.WriteOK()
 	})

--- a/cmd_generic.go
+++ b/cmd_generic.go
@@ -472,6 +472,11 @@ func (m *Miniredis) cmdRename(c *server.Peer, cmd string, args []string) {
 			return
 		}
 
+		if opts.from == opts.to {
+			c.WriteOK()
+			return
+		}
+
 		db.rename(opts.from, opts.to)
 		c.WriteOK()
 	})

--- a/cmd_generic_test.go
+++ b/cmd_generic_test.go
@@ -574,11 +574,25 @@ func TestRename(t *testing.T) {
 		proto.Error("ERR no such key"),
 	)
 
-	// Same key
+	// Same key (non-existing)
 	mustDo(t, c,
 		"RENAME", "from", "from",
 		proto.Error("ERR no such key"),
 	)
+
+	t.Run("same key", func(t *testing.T) {
+		s.Set("same", "value")
+		s.SetTTL("same", time.Second*123)
+		mustOK(t, c, "RENAME", "same", "same")
+		equals(t, true, s.Exists("same"))
+		s.CheckGet(t, "same", "value")
+		equals(t, time.Second*123, s.TTL("same"))
+
+		s.HSet("samehash", "field", "value")
+		mustOK(t, c, "RENAME", "samehash", "samehash")
+		equals(t, true, s.Exists("samehash"))
+		equals(t, "value", s.HGet("samehash", "field"))
+	})
 
 	t.Run("string key", func(t *testing.T) {
 		s.Set("from", "value")

--- a/db.go
+++ b/db.go
@@ -100,6 +100,9 @@ func (db *RedisDB) move(key string, to *RedisDB) bool {
 }
 
 func (db *RedisDB) rename(from, to string) {
+	if from == to {
+		return
+	}
 	db.del(to, true)
 	switch db.t(from) {
 	case keyTypeString:


### PR DESCRIPTION
**Problem**:
When calling RENAME with identical source and destination keys (RENAME key key) on an existing key, miniredis would delete the key in db.del(to, true), fail to find its type in db.t(from), and trigger a panic: panic("missing case").

**Solution**:
In cmdRename, if the key exists and from == to, return +OK immediately (consistent with Redis ≥ 3.2.0 behavior where this is a no-op).
Added a safeguard check in db.rename(from, to) to return early if from == to.
Added unit test TestRename/same_key in cmd_generic_test.go verifying that RENAME key key succeeds and preserves value and TTL.